### PR TITLE
Fix issues when starting aGiT from empty directory.

### DIFF
--- a/agit/backends/proxy_agents.py
+++ b/agit/backends/proxy_agents.py
@@ -156,5 +156,10 @@ def available_backends() -> list[str]:
 
 
 def make_proxy_agent(name: str) -> ProxyAgent:
-    agent_class = _AGENTS.get(name, OpenCodeProxyAgent)
+    # Raise on an unknown backend rather than silently substituting one: a stale
+    # or mistyped backend name must surface, not quietly launch the wrong agent.
+    try:
+        agent_class = _AGENTS[name]
+    except KeyError:
+        raise ValueError(f"Unknown backend {name!r}; choose one of {', '.join(available_backends())}.") from None
     return agent_class()

--- a/agit/cli.py
+++ b/agit/cli.py
@@ -54,7 +54,13 @@ def _discover_or_init(path: Path) -> GitRepo | None:
     run outside a Git repository, so if the user declines (or we can't prompt),
     return None and let the caller stop."""
     try:
-        return GitRepo.discover(path)
+        repo = GitRepo.discover(path)
+        # A user who ran `git init` themselves leaves an unborn HEAD (no commits),
+        # which aGiT's worktree setup cannot use. Seed an initial commit so an
+        # otherwise-empty repository starts cleanly.
+        if repo.ensure_born():
+            print(f"Seeded an initial commit in empty repository {repo.repo}")
+        return repo
     except GitError:
         pass
     if not (sys.stdin.isatty() and sys.stdout.isatty()):

--- a/agit/git.py
+++ b/agit/git.py
@@ -47,8 +47,24 @@ class GitRepo:
         if process.returncode != 0:
             raise GitError(f"git init failed in {path}:\n{process.stderr.strip()}")
         repo = cls.discover(path)
-        repo._run(["git", "commit", "--allow-empty", "-m", "Initial commit"])
+        repo.ensure_born()
         return repo
+
+    def has_commits(self) -> bool:
+        """True once the repository has at least one commit (a born HEAD)."""
+        return self._run(["git", "rev-parse", "--verify", "--quiet", "HEAD"], check=False).returncode == 0
+
+    def ensure_born(self) -> bool:
+        """Make sure HEAD points at a commit. A freshly `git init`-ed repository
+        has an unborn branch with no commits, which aGiT cannot run on (every
+        session is a worktree, and a worktree needs a valid HEAD). Seed an empty
+        initial commit so the repo is usable; any pre-existing files are left
+        untracked for aGiT's normal pre-agent user-commit flow. Returns True if a
+        seed commit was created, False if HEAD was already born."""
+        if self.has_commits():
+            return False
+        self._run(["git", "commit", "--allow-empty", "-m", "Initial commit"])
+        return True
 
     def status_short(self) -> str:
         return self._run(["git", "status", "--short"]).stdout

--- a/agit/state.py
+++ b/agit/state.py
@@ -118,7 +118,16 @@ class AgitState:
 
     @property
     def backend(self) -> str:
-        return str(self.data.get("backend") or "opencode")
+        # Honour the configured default (not a hardcoded backend) when the record
+        # has no backend yet, or when the stored value is no longer a known
+        # backend, so a missing/stale entry never silently launches the wrong
+        # agent (and make_proxy_agent never receives an invalid name).
+        from agit.backends.proxy_agents import available_backends
+
+        stored = self.data.get("backend")
+        if stored and stored in available_backends():
+            return str(stored)
+        return self._default_backend
 
     @backend.setter
     def backend(self, value: str) -> None:

--- a/tests/test_backends_and_config.py
+++ b/tests/test_backends_and_config.py
@@ -1,6 +1,8 @@
 import json
 from pathlib import Path
 
+import pytest
+
 from agit.backends.claude import ClaudeBackend
 from agit.backends.proxy_agents import available_backends, make_proxy_agent
 from agit.global_config import GlobalConfig
@@ -28,8 +30,12 @@ def test_claude_proxy_agent_spawn_command_uses_session_id_and_resume():
     assert agent.spawn_command(Path("/repo"), session_id="u1", resume=True) == ["claude", "--resume", "u1"]
 
 
-def test_make_proxy_agent_defaults_to_opencode_for_unknown():
-    assert make_proxy_agent("nonsense").name == "opencode"
+def test_make_proxy_agent_raises_on_unknown_backend():
+    # An unknown/stale backend name must surface loudly, not silently launch
+    # OpenCode (which contradicts the configured default).
+    with pytest.raises(ValueError) as excinfo:
+        make_proxy_agent("nonsense")
+    assert "nonsense" in str(excinfo.value)
 
 
 def test_global_config_default_backend_persists(tmp_path):

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -24,6 +24,38 @@ def test_git_init_seeds_usable_repo(tmp_path):
     assert "file.txt" in repo.status_short()
 
 
+def test_git_init_repo_has_born_head(tmp_path):
+    repo = GitRepo.init(tmp_path)
+    assert repo.has_commits()
+
+
+def test_ensure_born_seeds_unborn_repo_and_is_idempotent(tmp_path):
+    subprocess.run(["git", "init"], cwd=tmp_path, capture_output=True, check=True)
+    repo = GitRepo.discover(tmp_path)
+    assert not repo.has_commits()  # fresh `git init`: unborn HEAD
+
+    assert repo.ensure_born() is True  # seeds an initial commit
+    assert repo.has_commits()
+    assert repo.current_branch() not in ("", "HEAD")  # worktree-usable HEAD
+
+    assert repo.ensure_born() is False  # already born: no-op
+
+
+def test_discover_or_init_seeds_empty_initialized_repo(tmp_path, capsys):
+    # A user who ran `git init` themselves (unborn HEAD) must start cleanly,
+    # leaving their own files untracked for aGiT's user-commit flow.
+    subprocess.run(["git", "init"], cwd=tmp_path, capture_output=True, check=True)
+    (tmp_path / "existing.txt").write_text("mine\n", encoding="utf-8")
+
+    repo = cli._discover_or_init(tmp_path)
+
+    assert repo is not None
+    assert repo.has_commits()
+    assert repo.current_branch() not in ("", "HEAD")
+    assert "existing.txt" in repo.untracked_files()
+    assert "Seeded an initial commit" in capsys.readouterr().out
+
+
 def test_discover_or_init_returns_existing_repo(tmp_path, monkeypatch):
     GitRepo.init(tmp_path)
     asked = []

--- a/tests/test_state.py
+++ b/tests/test_state.py
@@ -11,6 +11,26 @@ def test_state_is_repository_local(tmp_path):
     assert loaded.declined_untracked() == ["new.py"]
 
 
+def test_backend_defaults_to_configured_default_not_opencode(tmp_path):
+    # A fresh repo with no recorded backend must honour the configured default
+    # rather than silently falling back to a hardcoded backend.
+    state = AgitState(tmp_path, default_backend="claude")
+    assert state.backend == "claude"
+
+    # An explicitly null/empty stored backend also falls back to the default.
+    state.data["backend"] = None
+    assert state.backend == "claude"
+
+    # A stale/unknown stored backend is coerced to the default rather than passed
+    # through (which would later raise in make_proxy_agent).
+    state.data["backend"] = "retired-agent"
+    assert state.backend == "claude"
+
+    # A known stored backend is honoured as-is.
+    state.data["backend"] = "opencode"
+    assert state.backend == "opencode"
+
+
 def test_state_prunes_declined_untracked_files(tmp_path):
     state = AgitState(tmp_path)
     state.add_declined(["ignored.log", "keep.py", "removed.py"])


### PR DESCRIPTION
# Full Subject

This session is being continued from a previous conversation that ran out of context. The summary below covers the earlier portion of the conversation. Summary: 1. Primary Request and Intent: The user is iteratively improving `agit` (Python CLI/TUI wrapping Claude Code / OpenCode + Git, committing agent changes with traceable metadata), while
 running agit ON agit itself (dogfooding). Requests in chronological
order: - "When I start agit in the current repo that has not used agit before, why can't I find existing Claude sessions in the agit session list?" - Clarified: "the worktrees are emptied whenever agit quits, so the sessions should not be obtained from there. The session list should be solely obtained from the backend agent's session record, with the only exception that if agit was run before and the session was named, you can obtain the name from the agit record." - "When agit starts, you can open the backend with the -c flag; if the current session has no name, prompt the user to name the session" (answered via AskUserQuestion: continue Repo's latest conversation; keep existing name
 else prompt). - "This didn't work. Even if i choose a session to resume
 from, agit still started a new session from scratch and the existing
session context is not there." - "Would it be better to use the same transcript in the base directory, then point the working directory to the worktree when starting claude or opencode? Otherwise, it seems new context in the session will be lost when someone starts claude or opencode directly without agit." - "Link agit-born sessions into the repo root" - "Why can OpenCode session be resumed by id from anywhere if
 the session files are in different directories?" - Picker bug (reported
 3 times): "If I switch session using Claude's native option triggered
by pressing the leftarrow key twice... horizontal lines between lines that don't disappear afterwards. If I press Esc on the session choice page, agit quits immediately without any message. When I restart agit, a
 new session gets started, but if I restart a second time, the previous
session resumes." - "Is there a way to make sure the agent only edits inside the worktree of the session?" (already done in a prior turn — sandbox) - "If agit is started in a non-git directory, prompt the user to initialize the git directory, run git init if the user agrees" + "If the user disagrees, stop agit since agit cannot run in non-git directories" - "Make sure that agit cleans up things at startup, if something is not cleaned properly when existing non-gracefully... avoid what we saw before that restart after Esc-related issue (now fixed) made
 agit work improperly, but it works after a second restart." - "If the
user switches branch in git, outside agit, make sure that nothing breaks
 and if needed pause worktree branch merging with a pop message in agit
for the user" - "But agit cleans up everything when exiting. Will the unmerged branches be preserved past exit?" (MOST RECENT) - "You mentioned that the working directory is in the worktree, but that seems to be an open issue if resuming from an existing session: https://github.com/anthropics/claude-code/issues/58591 Could you check whether you have indeed implemented having the worktree as the working directory?" - "Add the drift guard. In the agit message, also explain what can be done if such a drift happens." 2. Key Technical Concepts: - Python TUI proxy: `pyte.HistoryScreen` + PTY (`pty.fork`), full-screen repaint wrapped in synchronized output (DECSET 2026). - Multi-session multiplexer; per-backend worktree sessions; base-merge-only model (agent
 runs in worktree, base advanced only by FF integration). - Claude
transcripts: per-directory files `~/.claude/projects/<encoded- cwd>/<id>.jsonl`; `claude --resume <id>` is CWD-SCOPED (reads cwd's project dir), `-c`/`--continue` explicitly cwd-scoped. - OpenCode: global SQLite DB at `~/.local/share/opencode/storage/opencode.db`, `session` table keyed by `id` with a `directory` column (metadata only);
 resume-by-id is global. - macOS `sandbox-exec` worktree confinement
(deny base except `.git` + worktree); nested sandboxing forbidden. - Git
 worktrees: created detached at base; turn branches
`agit/<backend>/<session>/tN` lazy; `git merge --ff-only` advances the CHECKED-OUT branch. - Claude Code issue #58591: `--resume` can restore session's saved cwd, ignoring launch cwd. - pytest; tests use `ProxyRunner.__new__(ProxyRunner)` + manual attr setup + monkeypatch. 3.
 Files and Code Sections: - IMPORTANT: I edit the WORKTREE path
`/Users/s.wang9/Code/agit/.agit/worktrees/session-1/agit/...` (sandbox blocks base writes). agit auto-commits + integrates worktree edits to `dev`. - `agit/proxy.py` (worktree copy): bulk of changes. - `__init__`:
 added `self.raw_capture` (AGIT_DEBUG_RAW), `self.debug_proxy` (now
implied by raw_capture), `self._diag_run =
time.strftime("%Y%m%d-%H%M%S")`, `self._integration_paused = False`, `self._base_drift_check_at = 0.0`. - `_resumable_sessions`: now `self.backend.list_sessions(self.base_repo.repo)` sorted newest-first, capped. - `_agit_named_sessions`: reads root `session_names` + `backend_sessions` record. - `_setup_base_merge_only_session`: continues
 repo's latest (durable record else
`latest_session_id(base_repo.repo)`); `_resolve_startup_session_name` (keep user name / prompt); `_repo_latest_session_id`, `_first_free_session_name`, `_prompt_startup_name` (cooked-mode input).
- `_stage_backend_resume` (top of `_initialize_session_baseline`) → `backend.ensure_resumable`. - `_mirror_session_to_base` (in `_finish_agent_parse_if_ready`) → `backend.mirror_to_base`. - `_diag_path(kind)`: `(base_repo.repo or
repo.repo)/.agit/f"{kind}-{_diag_run}.log"`. `_debug` + `_raw_capture` use it. - `_raw_capture(tag, data)`: writes `< / > / EOF` chunks. Called
 in `_loop` (after drain output, before EOF break, after stdin read). -
`_relaunch_backend_or_exit`: on backend exit (single session), `_restart_agent` to relaunch+resume; crash-loop guard (≥3 exits in 12s →
 `_finalize_on_backend_exit`). Wired into BOTH `master_fd` EOF path AND
`waitpid` path: `if self._handle_active_session_exit(): continue; if self._relaunch_backend_or_exit(): continue; break/return`. - `_open_session_worktree`: `_is_valid_worktree(path)` (has `.git` + resolvable branch) before reuse; else `shutil.rmtree` leftover + recreate. - `_cleanup_stale_state_on_startup` (called in run() before `_setup_base_merge_only_session`): `worktree_prune` + filesystem sweep of `.agit/worktrees/` removing dirs not registered and not valid worktrees. - `_confine_to_worktree` (sandbox wrap), `_setup_worktree_confinement_notice`, `_warn_if_base_edited`. - `_warn_if_cwd_drifted`: compares
`backend.recorded_working_dir(session_id)` to worktree; warns once with #58591 remediation ("Ctrl-G → session → start a NEW session"). - `_check_base_branch_drift` (loop, runs FIRST, 2s throttle): if `base_repo.current_branch() != self._base_branch` → set `_integration_paused`, popup; resumes + message when switched back. - `_integrate_turn_or_conflict`: `if getattr(self, "_integration_paused", False): return "skip"`. - `_sync_idle_worktrees_to_base`: `if getattr(self, "_integration_paused", False): return`. - `_advance_base_to`: hard guard `current =
self.base_repo.current_branch(); if current != self._base_branch: raise RuntimeError(...)` before `merge_ff_only`. - `_remove_worktree_on_exit` (MOST RECENT EDIT): changed guard to: ```python branch = self.repo.current_branch() if branch.startswith("agit/"): self.base_repo.rev_parse(self._base_branch) # raises (→ keep) if base ref gone if self.base_repo.log_range(self._base_branch, branch): return # commits ahead of base → unintegrated; keep it ``` - `agit/claude_session.py` (worktree): added `prepare_resume` (hardlink, copy fallback), `_find_session_file`, `link_session`, `session_cwd(session_id)` (reads last `cwd` field from newest `<id>.jsonl`). `__all__` updated. - `agit/backends/proxy_agents.py` (worktree): added protocol + Claude/OpenCode impls of `ensure_resumable`, `mirror_to_base`, `recorded_working_dir`. OpenCode returns False/None; Claude delegates to claude_session. - `agit/git.py` (worktree): added `GitRepo.init(path)` (git init + `git commit --allow- empty -m "Initial commit"` to seed HEAD; user files left untracked). `_run` uses `cwd=self.repo`. `merge_ff_only(ref)` = `git merge --ff-only
 ref`. `log_range(base, head)` uses `check=False`. `rev_parse(ref)` uses
 check=True (raises on missing). - `agit/cli.py` (worktree):
`_discover_or_init(path)` — discover, else prompt (TTY) "Initialize one here with `git init`? [y/N]"; agree → `GitRepo.init`; decline/non- interactive → print + return None (agit stops). - `agit/state.py`: `session_names` map; `session_name_for(id)`, `name_session(id, name)`. -
 `agit/global_config.py`: `sandbox` property (default True);
`timings`/`DEFAULT_TIMINGS` added by user/linter (base_poll_seconds=3.0,
 background_poll_seconds=2.0, file_stable_seconds=8.0,
child_idle_seconds=4.0, parse_cooldown_seconds=10.0, base_edit_check_seconds=3.0, cwd_check_seconds=3.0). - `agit/sandbox.py`: `is_enabled`, `is_available` (macOS+sandbox-exec), `build_profile(base, worktree)` (deny base + worktrees-root, allow `.git` + this worktree), `wrap_command`. - Tests (worktree): `tests/test_cli.py` (new), `tests/test_sandbox.py` (nested-sandbox skip probe), plus additions to `test_proxy.py`, `test_claude_session.py`, `test_state.py`. `test_proxy.py` got `import pytest` added. - Memory: `/Users/s.wang9/.claude/projects/-Users-s-wang9-Code-agit/memory/per- backend-sessions.md` (extensively updated), `worktree-confinement.md` (created), `MEMORY.md` index. 4. Errors and fixes: - Resume started fresh → wrong assumption that `--resume` is global; it's cwd-scoped. Fixed with `prepare_resume` staging transcript. USER FEEDBACK: "This didn't work." - Picker bug: multiple wrong guesses. USER repeatedly: "It
 still quits on Esc", "agit still exits when pressing Esc on that page".
 Root cause: Claude exits cleanly on Esc; agit followed it. My first
relaunch fix only covered `master_fd` EOF path; the `waitpid` path still
 exited — fixed by routing waitpid through same relaunch logic. -
Diagnostic logs vanished → they were in the ephemeral worktree `.agit/` which agit removes on exit. Fixed by writing to base `.agit/` per-run files (`_diag_path`). - `git init` alone leaves unborn HEAD (rev-parse --abbrev-ref HEAD exits 128) → breaks worktree add. Fixed by seeding empty initial commit in `GitRepo.init`. - Test failures: fake stream objects broke `print` (fixed by patching only `isatty`); `pytest` not imported in test_proxy.py (added `import pytest`); nested sandbox-exec test failed inside agit's sandbox (added skip probe); `_open_session_worktree` test asserted wrong thing (changed to check `.agit` marker cleared); `_relaunch` test stub didn't mirror guard (fixed). 5. Problem Solving: - Established the agit-on-agit hall-of- mirrors: I'm sandboxed to the worktree; edits must go to worktree; agit integrates to dev; user restarts to pick up changes. Code-location confusion resolved (base + worktree synced at commits like `379922f`, `c8107e3`). - Verified worktree IS the cwd via transcript `cwd` field; sandbox is backstop for #58591 drift. - Confirmed unmerged work preserved past exit (worktree+branch kept when ahead of base), hardened deleted-base edge. 6. All user messages: - "When I start agit in the current repo that has not used agit before, why can't I find existing Claude sessions in the agit session list?" - "No, as I said before, the worktrees are emptied whenever agit quits, so the sessions should not be
 obtained from there. The session list should be solely obtained from
the backend agent's session record, with the only exception that if agit
 was run before and the session was named, you can obtain the name from
the agit record." - "When agit starts, you can open the backend with the
 -c flag; if the current session has no name, prompt the user to name
the session" - "This didn't work. Even if i choose a session to resume from, agit still started a new session from scratch and the existing session context is not there." - "Would it be better to use the same transcript in the base directory, then point the working directory to the worktree when starting claude or opencode? Otherwise, it seems new context in the session will be lost when someone starts claude or opencode directly without agit." - "Link agit-born sessions into the repo root" - "Why can OpenCode session be resumed by id from anywhere if
 the session files are in different directories?" - "This is still not
fixed: If I switch session using Claude's native option triggered by pressing the leftarrow key twice... horizontal lines... If I press Esc on the session choice page, agit quits immediately without any message. When I restart agit, a new session gets started, but if I restart a second time, the previous session resumes." - "I reproduced it, read the
 logs" - "Sorry, you can read now" - "This is in agit right after exit
on Esc, so you can expect some issues in this environment" - "I ran script -q /tmp/agit-repro.script agit on a different repo and you can read it now" - "It still quits on Esc. See if you can see the logs" - "ok, yes now it works. You mentioned that the working directory is in the worktree, but that seems to be an open issue if resuming from an existing session: https://github.com/anthropics/claude-code/issues/58591
 Could you check whether you have indeed implemented having the worktree
 as the working directory?" - "Add the drift guard. In the agit message,
 also explain what can be done if such a drift happens." - "If agit is
started in a non-git directory, prompt the user to initialize the git directory, run git init if the user agrees" - "If the user disagrees, stop agit since agit cannot run in non-git directories" - "Make sure that agit cleans up things at startup, if something is not cleaned properly when existing non-gracefully. This should avoid what we saw before that restart after Esc-related issue (now fixed) made agit work improperly, but it works after a second restart." - "If the user switches branch in git, outside agit, make sure that nothing breaks and if needed pause worktree branch merging with a pop message in agit for the user" - "But agit cleans up everything when exiting. Will the unmerged branches be preserved past exit?" 7. Pending Tasks: - None explicitly pending beyond the just-completed branch-preservation verification/hardening. 8. Current Work: Immediately before this summary, I addressed "But agit cleans up everything when exiting. Will the unmerged branches be preserved past exit?" I verified from code that
 `_remove_worktree_on_exit` keeps a worktree (and its turn branch) when
`log_range(self._base_branch, branch)` shows commits ahead — so for a branch SWITCH (old base ref survives), unmerged work is preserved. I identified an edge: if the base branch is DELETED/renamed, `log_range` (check=False) returns empty → would be read as "merged" → worktree removed → work lost. I hardened `_remove_worktree_on_exit` (worktree copy) by adding `self.base_repo.rev_parse(self._base_branch)` before the
 `log_range` check (raises on unresolvable base → caught by outer
`except Exception: return` → keep). I added 3 tests to `tests/test_proxy.py`:
`test_exit_keeps_worktree_with_unintegrated_commits`, `test_exit_keeps_worktree_when_base_ref_unresolvable`, `test_exit_removes_fully_merged_worktree` (via `_exit_removal_runner` helper). Full suite: **270 passed, 1 skipped**. I then updated memory `per-backend-sessions.md` to document the preservation hardening. The task is complete; I had NOT yet written a final text response to the user summarizing this verification/fix. 9. Optional Next Step: Write a concise text response to the user answering "Will the unmerged branches be preserved past exit?" — confirming: YES for a branch switch (the `_remove_worktree_on_exit` guard keeps any worktree whose turn branch has commits ahead of base, and the drift-paused integration leaves work ahead of base → preserved); the worktree+branch are surfaced/reconciled on next startup by `_reconcile_sessions_on_startup` (and untouched by `_cleanup_stale_state_on_startup`); and noting I hardened the deleted/renamed-base edge case via the new `rev_parse` check so work isn't dropped when the base ref is unresolvable. State 270 tests pass and that changes are in the worktree and will integrate to `dev`/take effect after restart. This directly concludes the most recent task; no new/tangential work should be started without user confirmation. If you need specific details from before compaction (like exact code snippets, error messages, or content you generated), read the full transcript at: /Users/s.wang9/.claude/projects/-Users-s-wang9-Code-agit--agit- worktrees-session-1/63fc2742-71d5-4295-8966-fc3b00756414.jsonl Continue the conversation from where it left off without asking the user any further questions. Resume directly — do not acknowledge the summary, do not recap what was happening, do not preface with "I'll continue" or similar. Pick up the last task as if the break never happened. / When starting agit from an empty git initialized directory, it gives an error
 and agit won't start. Please check this and make sure to add tests
ensuring this works. In addition, although the global config shows claude as the default backend, agit still started OpenCode on empty repo, so this should be fixed too.

# Interaction Trace

## User

This session is being continued from a previous conversation that ran out of context. The summary below covers the earlier portion of the conversation.

Summary:
1. Primary Request and Intent: The user is iteratively improving `agit` (Python CLI/TUI wrapping Claude Code / OpenCode + Git, committing agent changes with traceable metadata), while running agit ON agit itself (dogfooding). Requests in chronological order:
   - "When I start agit in the current repo that has not used agit before, why can't I find existing Claude sessions in the agit session list?"
   - Clarified: "the worktrees are emptied whenever agit quits, so the sessions should not be obtained from there. The session list should be solely obtained from the backend agent's session record, with the only exception that if agit was run before and the session was named, you can
 obtain the name from the agit record."
   - "When agit starts, you can open the backend with the -c flag; if the current session has no name, prompt the user to name the session" (answered via AskUserQuestion: continue Repo's latest conversation; keep
 existing name else prompt).
   - "This didn't work. Even if i choose a session to resume from, agit still started a new session from scratch and the existing session context is not there."
   - "Would it be better to use the same transcript in the base directory, then point the working directory to the worktree when starting claude or opencode? Otherwise, it seems new context in the session will be lost when someone starts claude or opencode directly without agit."
   - "Link agit-born sessions into the repo root"
   - "Why can OpenCode session be resumed by id from anywhere if the session files are in different directories?"
   - Picker bug (reported 3 times): "If I switch session using Claude's native option triggered by pressing the leftarrow key twice... horizontal lines between lines that don't disappear afterwards. If I press Esc on the session choice page, agit quits immediately without any
 message. When I restart agit, a new session gets started, but if I
restart a second time, the previous session resumes."
   - "Is there a way to make sure the agent only edits inside the worktree of the session?" (already done in a prior turn — sandbox)
   - "If agit is started in a non-git directory, prompt the user to initialize the git directory, run git init if the user agrees" + "If the
 user disagrees, stop agit since agit cannot run in non-git directories"
   - "Make sure that agit cleans up things at startup, if something is not cleaned properly when existing non-gracefully... avoid what we saw before that restart after Esc-related issue (now fixed) made agit work improperly, but it works after a second restart."
   - "If the user switches branch in git, outside agit, make sure that nothing breaks and if needed pause worktree branch merging with a pop message in agit for the user"
   - "But agit cleans up everything when exiting. Will the unmerged branches be preserved past exit?" (MOST RECENT)
   - "You mentioned that the working directory is in the worktree, but that seems to be an open issue if resuming from an existing session: https://github.com/anthropics/claude-code/issues/58591 Could you check whether you have indeed implemented having the worktree as the working directory?"
   - "Add the drift guard. In the agit message, also explain what can be done if such a drift happens."

2. Key Technical Concepts:
   - Python TUI proxy: `pyte.HistoryScreen` + PTY (`pty.fork`), full- screen repaint wrapped in synchronized output (DECSET 2026).
   - Multi-session multiplexer; per-backend worktree sessions; base- merge-only model (agent runs in worktree, base advanced only by FF integration).
   - Claude transcripts: per-directory files `~/.claude/projects/<encoded-cwd>/<id>.jsonl`; `claude --resume <id>` is
 CWD-SCOPED (reads cwd's project dir), `-c`/`--continue` explicitly cwd-
scoped.
   - OpenCode: global SQLite DB at `~/.local/share/opencode/storage/opencode.db`, `session` table keyed by `id` with a `directory` column (metadata only); resume-by-id is global.
   - macOS `sandbox-exec` worktree confinement (deny base except `.git`
+ worktree); nested sandboxing forbidden.
   - Git worktrees: created detached at base; turn branches `agit/<backend>/<session>/tN` lazy; `git merge --ff-only` advances the CHECKED-OUT branch.
   - Claude Code issue #58591: `--resume` can restore session's saved cwd, ignoring launch cwd.
   - pytest; tests use `ProxyRunner.__new__(ProxyRunner)` + manual attr setup + monkeypatch.

3. Files and Code Sections:
   - IMPORTANT: I edit the WORKTREE path `/Users/s.wang9/Code/agit/.agit/worktrees/session-1/agit/...` (sandbox blocks base writes). agit auto-commits + integrates worktree edits to `dev`.
   - `agit/proxy.py` (worktree copy): bulk of changes.
     - `__init__`: added `self.raw_capture` (AGIT_DEBUG_RAW), `self.debug_proxy` (now implied by raw_capture), `self._diag_run = time.strftime("%Y%m%d-%H%M%S")`, `self._integration_paused = False`, `self._base_drift_check_at = 0.0`.
     - `_resumable_sessions`: now
`self.backend.list_sessions(self.base_repo.repo)` sorted newest-first, capped.
     - `_agit_named_sessions`: reads root `session_names` +
`backend_sessions` record.
     - `_setup_base_merge_only_session`: continues repo's latest
(durable record else `latest_session_id(base_repo.repo)`); `_resolve_startup_session_name` (keep user name / prompt); `_repo_latest_session_id`, `_first_free_session_name`, `_prompt_startup_name` (cooked-mode input).
     - `_stage_backend_resume` (top of `_initialize_session_baseline`) →
 `backend.ensure_resumable`.
     - `_mirror_session_to_base` (in `_finish_agent_parse_if_ready`) → `backend.mirror_to_base`.
     - `_diag_path(kind)`: `(base_repo.repo or
repo.repo)/.agit/f"{kind}-{_diag_run}.log"`. `_debug` + `_raw_capture` use it.
     - `_raw_capture(tag, data)`: writes `< / > / EOF` chunks. Called in
 `_loop` (after drain output, before EOF break, after stdin read).
     - `_relaunch_backend_or_exit`: on backend exit (single session), `_restart_agent` to relaunch+resume; crash-loop guard (≥3 exits in 12s →
 `_finalize_on_backend_exit`). Wired into BOTH `master_fd` EOF path AND
`waitpid` path: `if self._handle_active_session_exit(): continue; if self._relaunch_backend_or_exit(): continue; break/return`.
     - `_open_session_worktree`: `_is_valid_worktree(path)` (has `.git`
+ resolvable branch) before reuse; else `shutil.rmtree` leftover + recreate.
     - `_cleanup_stale_state_on_startup` (called in run() before
`_setup_base_merge_only_session`): `worktree_prune` + filesystem sweep of `.agit/worktrees/` removing dirs not registered and not valid worktrees.
     - `_confine_to_worktree` (sandbox wrap),
`_setup_worktree_confinement_notice`, `_warn_if_base_edited`.
     - `_warn_if_cwd_drifted`: compares
`backend.recorded_working_dir(session_id)` to worktree; warns once with #58591 remediation ("Ctrl-G → session → start a NEW session").
     - `_check_base_branch_drift` (loop, runs FIRST, 2s throttle): if
`base_repo.current_branch() != self._base_branch` → set `_integration_paused`, popup; resumes + message when switched back.
     - `_integrate_turn_or_conflict`: `if getattr(self,
"_integration_paused", False): return "skip"`.
     - `_sync_idle_worktrees_to_base`: `if getattr(self,
"_integration_paused", False): return`.
     - `_advance_base_to`: hard guard `current =
self.base_repo.current_branch(); if current != self._base_branch: raise RuntimeError(...)` before `merge_ff_only`.
     - `_remove_worktree_on_exit` (MOST RECENT EDIT): changed guard to:
       ```python
       branch = self.repo.current_branch()
       if branch.startswith("agit/"):
           self.base_repo.rev_parse(self._base_branch)  # raises (→
keep) if base ref gone
           if self.base_repo.log_range(self._base_branch, branch):
               return  # commits ahead of base → unintegrated; keep it
       ```
   - `agit/claude_session.py` (worktree): added `prepare_resume` (hardlink, copy fallback), `_find_session_file`, `link_session`, `session_cwd(session_id)` (reads last `cwd` field from newest `<id>.jsonl`). `__all__` updated.
   - `agit/backends/proxy_agents.py` (worktree): added protocol + Claude/OpenCode impls of `ensure_resumable`, `mirror_to_base`, `recorded_working_dir`. OpenCode returns False/None; Claude delegates to
 claude_session.
   - `agit/git.py` (worktree): added `GitRepo.init(path)` (git init + `git commit --allow-empty -m "Initial commit"` to seed HEAD; user files left untracked). `_run` uses `cwd=self.repo`. `merge_ff_only(ref)` = `git merge --ff-only ref`. `log_range(base, head)` uses `check=False`. `rev_parse(ref)` uses check=True (raises on missing).
   - `agit/cli.py` (worktree): `_discover_or_init(path)` — discover, else prompt (TTY) "Initialize one here with `git init`? [y/N]"; agree → `GitRepo.init`; decline/non-interactive → print + return None (agit stops).
   - `agit/state.py`: `session_names` map; `session_name_for(id)`, `name_session(id, name)`.
   - `agit/global_config.py`: `sandbox` property (default True); `timings`/`DEFAULT_TIMINGS` added by user/linter (base_poll_seconds=3.0,
 background_poll_seconds=2.0, file_stable_seconds=8.0,
child_idle_seconds=4.0, parse_cooldown_seconds=10.0, base_edit_check_seconds=3.0, cwd_check_seconds=3.0).
   - `agit/sandbox.py`: `is_enabled`, `is_available` (macOS+sandbox- exec), `build_profile(base, worktree)` (deny base + worktrees-root, allow `.git` + this worktree), `wrap_command`.
   - Tests (worktree): `tests/test_cli.py` (new), `tests/test_sandbox.py` (nested-sandbox skip probe), plus additions to `test_proxy.py`, `test_claude_session.py`, `test_state.py`. `test_proxy.py` got `import pytest` added.
   - Memory: `/Users/s.wang9/.claude/projects/-Users-s-wang9-Code- agit/memory/per-backend-sessions.md` (extensively updated), `worktree- confinement.md` (created), `MEMORY.md` index.

4. Errors and fixes:
   - Resume started fresh → wrong assumption that `--resume` is global; it's cwd-scoped. Fixed with `prepare_resume` staging transcript. USER FEEDBACK: "This didn't work."
   - Picker bug: multiple wrong guesses. USER repeatedly: "It still quits on Esc", "agit still exits when pressing Esc on that page". Root cause: Claude exits cleanly on Esc; agit followed it. My first relaunch fix only covered `master_fd` EOF path; the `waitpid` path still exited —
 fixed by routing waitpid through same relaunch logic.
   - Diagnostic logs vanished → they were in the ephemeral worktree `.agit/` which agit removes on exit. Fixed by writing to base `.agit/` per-run files (`_diag_path`).
   - `git init` alone leaves unborn HEAD (rev-parse --abbrev-ref HEAD exits 128) → breaks worktree add. Fixed by seeding empty initial commit in `GitRepo.init`.
   - Test failures: fake stream objects broke `print` (fixed by patching only `isatty`); `pytest` not imported in test_proxy.py (added `import pytest`); nested sandbox-exec test failed inside agit's sandbox (added skip probe); `_open_session_worktree` test asserted wrong thing (changed
 to check `.agit` marker cleared); `_relaunch` test stub didn't mirror
guard (fixed).

5. Problem Solving:
   - Established the agit-on-agit hall-of-mirrors: I'm sandboxed to the worktree; edits must go to worktree; agit integrates to dev; user restarts to pick up changes. Code-location confusion resolved (base + worktree synced at commits like `379922f`, `c8107e3`).
   - Verified worktree IS the cwd via transcript `cwd` field; sandbox is backstop for #58591 drift.
   - Confirmed unmerged work preserved past exit (worktree+branch kept when ahead of base), hardened deleted-base edge.

6. All user messages:
   - "When I start agit in the current repo that has not used agit before, why can't I find existing Claude sessions in the agit session list?"
   - "No, as I said before, the worktrees are emptied whenever agit quits, so the sessions should not be obtained from there. The session list should be solely obtained from the backend agent's session record, with the only exception that if agit was run before and the session was named, you can obtain the name from the agit record."
   - "When agit starts, you can open the backend with the -c flag; if the current session has no name, prompt the user to name the session"
   - "This didn't work. Even if i choose a session to resume from, agit still started a new session from scratch and the existing session context is not there."
   - "Would it be better to use the same transcript in the base directory, then point the working directory to the worktree when starting claude or opencode? Otherwise, it seems new context in the session will be lost when someone starts claude or opencode directly without agit."
   - "Link agit-born sessions into the repo root"
   - "Why can OpenCode session be resumed by id from anywhere if the session files are in different directories?"
   - "This is still not fixed: If I switch session using Claude's native option triggered by pressing the leftarrow key twice... horizontal lines... If I press Esc on the session choice page, agit quits immediately without any message. When I restart agit, a new session gets
 started, but if I restart a second time, the previous session resumes."
   - "I reproduced it, read the logs"
   - "Sorry, you can read now"
   - "This is in agit right after exit on Esc, so you can expect some issues in this environment"
   - "I ran script -q /tmp/agit-repro.script agit on a different repo and you can read it now"
   - "It still quits on Esc. See if you can see the logs"
   - "ok, yes now it works. You mentioned that the working directory is in the worktree, but that seems to be an open issue if resuming from an existing session: https://github.com/anthropics/claude-code/issues/58591
 Could you check whether you have indeed implemented having the worktree
 as the working directory?"
   - "Add the drift guard. In the agit message, also explain what can be done if such a drift happens."
   - "If agit is started in a non-git directory, prompt the user to initialize the git directory, run git init if the user agrees"
   - "If the user disagrees, stop agit since agit cannot run in non-git directories"
   - "Make sure that agit cleans up things at startup, if something is not cleaned properly when existing non-gracefully. This should avoid what we saw before that restart after Esc-related issue (now fixed) made
 agit work improperly, but it works after a second restart."
   - "If the user switches branch in git, outside agit, make sure that nothing breaks and if needed pause worktree branch merging with a pop message in agit for the user"
   - "But agit cleans up everything when exiting. Will the unmerged branches be preserved past exit?"

7. Pending Tasks:
   - None explicitly pending beyond the just-completed branch- preservation verification/hardening.

8. Current Work: Immediately before this summary, I addressed "But agit cleans up everything when exiting. Will the unmerged branches be preserved past exit?" I verified from code that `_remove_worktree_on_exit` keeps a worktree (and its turn branch) when `log_range(self._base_branch, branch)` shows commits ahead — so for a branch SWITCH (old base ref survives), unmerged work is preserved. I identified an edge: if the base
 branch is DELETED/renamed, `log_range` (check=False) returns empty →
would be read as "merged" → worktree removed → work lost. I hardened `_remove_worktree_on_exit` (worktree copy) by adding `self.base_repo.rev_parse(self._base_branch)` before the `log_range` check (raises on unresolvable base → caught by outer `except Exception: return` → keep). I added 3 tests to `tests/test_proxy.py`: `test_exit_keeps_worktree_with_unintegrated_commits`, `test_exit_keeps_worktree_when_base_ref_unresolvable`, `test_exit_removes_fully_merged_worktree` (via `_exit_removal_runner` helper). Full suite: **270 passed, 1 skipped**. I then updated memory `per-backend-sessions.md` to document the preservation hardening. The task is complete; I had NOT yet written a final text response to the user summarizing this verification/fix.

9. Optional Next Step: Write a concise text response to the user answering "Will the unmerged branches be preserved past exit?" — confirming: YES for a branch switch (the `_remove_worktree_on_exit` guard keeps any worktree whose turn branch has commits ahead of base, and the drift-paused integration leaves work ahead of base → preserved); the worktree+branch are surfaced/reconciled on next startup by
`_reconcile_sessions_on_startup` (and untouched by `_cleanup_stale_state_on_startup`); and noting I hardened the deleted/renamed-base edge case via the new `rev_parse` check so work isn't dropped when the base ref is unresolvable. State 270 tests pass and that changes are in the worktree and will integrate to `dev`/take effect after restart. This directly concludes the most recent task; no new/tangential work should be started without user confirmation.

If you need specific details from before compaction (like exact code snippets, error messages, or content you generated), read the full transcript at: /Users/s.wang9/.claude/projects/-Users-s-wang9-Code-agit --agit-worktrees-session-1/63fc2742-71d5-4295-8966-fc3b00756414.jsonl Continue the conversation from where it left off without asking the user
 any further questions. Resume directly — do not acknowledge the
summary, do not recap what was happening, do not preface with "I'll continue" or similar. Pick up the last task as if the break never happened.

## User

When starting agit from an empty git initialized directory, it gives an error and agit won't start. Please check this and make sure to add tests
 ensuring this works. In addition, although the global config shows
claude as the default backend, agit still started OpenCode on empty repo, so this should be fixed too.

## Agent

The remaining matches are all legitimate (OpenCode's own CLI commands, install hint, and the package-level `DEFAULT_BACKEND` used only when the
 user has never chosen a default). Both fixes are complete.

## Summary

Two root causes, both fixed with tests.

### Issue 1 — empty `git init` dir errored out
A freshly `git init`-ed repo has an **unborn HEAD** (no commits). agit's
 `current_branch()` (`git rev-parse --abbrev-ref HEAD`) exits 128 on
that → `GitError` at `proxy.py:408`, before agit could start.

- `git.py`: added `has_commits()` and `ensure_born()` (seeds an empty `Initial commit` only when HEAD is unborn; leaves your files untracked for the normal user-commit flow). Refactored `GitRepo.init` to reuse it.
- `cli.py`: `_discover_or_init` now calls `ensure_born()` on the discovered repo, printing `Seeded an initial commit in empty repository …` when it does.

### Issue 2 — OpenCode launched despite `default_backend: claude` Two silent hardcoded `opencode` fallbacks that ignored the configured default:

- `backends/proxy_agents.py`: `make_proxy_agent` did `_AGENTS.get(name, OpenCodeProxyAgent)` — any unrecognized name silently became OpenCode. Now raises `ValueError` so a stale/mistyped backend surfaces.
- `state.py`: `backend` getter did `... or "opencode"`. Now falls back to the **configured default**, and also coerces an unknown/stale stored value to the default (so the newly-strict `make_proxy_agent` never gets garbage and can't crash agit on a corrupt `state.json`).

Verified on a real empty repo: it seeds `main`, leaves `existing.txt` untracked, and resolves `state.backend → claude → ClaudeProxyAgent`.

### Tests
8 new tests across `test_cli.py` (born-HEAD seeding, idempotent `ensure_born`, `_discover_or_init` on an empty repo), `test_state.py` (default/null/stale/known backend resolution), and `test_backends_and_config.py` (updated the old test that *codified* the opencode fallback → now asserts it raises). **278 passed, 1 skipped.**

Changes are in the worktree; they'll integrate to `dev` and take effect on restart.

# aGiT Metadata
commit_type: agent
backend: claude
model: claude-opus-4-8
session_name: session-1
agit_session_id: agit-56c8033f-bc52-4be4-a964-a6669f2385d0 backend_session_id: 63fc2742-71d5-4295-8966-fc3b00756414 context_tokens: 74224
tokens_since_last_commit_input: 35350
tokens_since_last_commit_cache_read: 4880543
tokens_since_last_commit_cache_write: 181532
tokens_since_last_commit_output: 59913
agit_version: 0.0.1