### PR TITLE
Add single check entrypoint and pre-push hook mirroring CI

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -1,6 +1,9 @@
-# Fast local checks that mirror the CI lint/format gates (.github/workflows/ci.yml).
-# Opt-in: run `uv run pre-commit install` once. Heavier checks (pytest, coverage,
-# mypy) stay in CI so commits remain quick.
+# Local git hooks that mirror the CI gates (.github/workflows/ci.yml).
+# Opt-in: run `make install-hooks` once (installs both the commit and push hooks).
+#
+#   commit stage : ruff lint + format + file hygiene (fast, keeps commits quick)
+#   push stage   : the full gate via scripts/check.sh (ruff + mypy + tests),
+#                  so a push that would break CI fails locally first.
 #
 # ruff config is shared from pyproject.toml ([tool.ruff]).
 repos:
@@ -19,3 +22,14 @@ repos:
       - id: check-yaml
       - id: check-merge-conflict
       - id: check-added-large-files
+
+  # Full CI-equivalent gate, run only on push (too heavy for every commit).
+  - repo: local
+    hooks:
+      - id: full-check
+        name: full check (ruff, mypy, tests + coverage)
+        entry: scripts/check.sh
+        language: script
+        stages: [pre-push]
+        pass_filenames: false
+        always_run: true

--- a/Makefile
+++ b/Makefile
@@ -1,0 +1,10 @@
+.PHONY: check install-hooks
+
+# Run the full local gate (mirrors CI): ruff, mypy, tests + coverage.
+check:
+	./scripts/check.sh
+
+# Install the opt-in git hooks: ruff/format on commit, full check on push.
+install-hooks:
+	uv run pre-commit install
+	uv run pre-commit install --hook-type pre-push

--- a/README.md
+++ b/README.md
@@ -16,14 +16,25 @@ This installs the `agit` command and the terminal UI dependency used for status 
 
 ### Contributing
 
-Install the optional pre-commit hooks for fast local lint/format on every commit (same checks as CI):
+Install dependencies and the optional git hooks:
 
 ```bash
 uv sync --group dev
-uv run pre-commit install
+make install-hooks
 ```
 
-The hooks run `ruff` (lint + format) and basic file hygiene. Tests, coverage, and type checks run in CI.
+This installs two hooks:
+
+- **commit** — `ruff` (lint + format) and basic file hygiene, so commits stay fast.
+- **push** — the full CI-equivalent gate (`ruff`, `mypy` vs the baseline, tests + coverage), so a push that would break CI fails locally first.
+
+Run the same full gate by hand at any time:
+
+```bash
+make check        # or: ./scripts/check.sh
+```
+
+This is the definition of "done" for a change — it mirrors CI exactly (`.github/workflows/ci.yml`).
 
 ## Usage
 

--- a/scripts/check.sh
+++ b/scripts/check.sh
@@ -1,0 +1,39 @@
+#!/usr/bin/env bash
+# Single local gate that mirrors CI (.github/workflows/ci.yml), in the same order:
+#   1. ruff lint        2. ruff format --check
+#   3. mypy vs the committed baseline (fails only on NEW errors)
+#   4. tests + coverage
+#
+# Definition of "done" for a change: this script exits 0. Run it before you
+# commit or push. It is also wired as a pre-push hook (see .pre-commit-config.yaml
+# and the Contributing section of the README), so a push that would break CI is
+# caught locally first.
+#
+# Regenerate the mypy baseline after an intentional burndown with:
+#   uv run mypy | uv run mypy-baseline sync
+set -euo pipefail
+
+cd "$(dirname "$0")/.."
+
+step() { printf '\n==> %s\n' "$*"; }
+
+step "ruff check"
+uv run ruff check agit/ tests/
+
+step "ruff format --check"
+uv run ruff format --check agit/ tests/
+
+step "mypy (new errors only)"
+# mypy exits non-zero because the committed baseline still carries known errors;
+# the authoritative result is mypy-baseline filter's exit (non-zero only on NEW
+# errors). Turn pipefail off for just this pipeline so the filter governs, exactly
+# as CI runs it (its default shell has no pipefail).
+set +o pipefail
+uv run mypy | uv run mypy-baseline filter || { status=$?; set -o pipefail; exit "$status"; }
+set -o pipefail
+
+step "tests + coverage"
+uv run coverage run -m pytest -q
+uv run coverage report
+
+printf '\nAll checks passed.\n'


### PR DESCRIPTION
## What

One local gate that mirrors CI (`.github/workflows/ci.yml`) exactly, so a change can't pass locally yet break CI on push.

- `scripts/check.sh` — ruff lint, ruff format --check, mypy vs baseline (new errors only), tests + coverage, in CI's order.
- Wired as a **pre-push** pre-commit hook (full gate on push; commit hook stays ruff-only and fast).
- `make check` runs it by hand; `make install-hooks` installs both hooks.
- README Contributing updated.

## Why

Pre-commit only covered ruff + file hygiene; mypy and pytest had no local enforcement, so "done" relied on remembering to run three separate commands. This makes the gate one command and hard to skip.

## Note

The mypy step disables pipefail for that one pipeline: `mypy` exits non-zero while the committed baseline still carries known errors, so the authoritative result is `mypy-baseline filter`'s exit (non-zero only on NEW errors) — matching how CI's default shell runs it.

Verified: `./scripts/check.sh` passes end-to-end on `dev`; pre-push hook runs the gate.

🤖 Generated with [Claude Code](https://claude.com/claude-code)