### PR TITLE
<aGiT> This session resolved aGiT issue #58: when the backend agent...

### DIFF
--- a/README.md
+++ b/README.md
@@ -143,7 +143,7 @@ On startup, aGiT reconciles worktrees left behind by previous runs: it integrate
 
 ### Commit message format
 
-aGiT commit messages use a consistent Markdown-style structure. The first line is the subject (prefixed with `<aGiT>` for agent commits — including backend-made commits aGiT amends, see `tag_backend_commits` under Configuration — `<aGiT-merge>` for agent-resolved merges, or left plain for user commits). When summarization is enabled the summary leads the message: its first line is the subject and the rest is the first paragraph of the body. The rest of the body is organized into `#` sections — `# Prompts` (when a summary takes the subject), `# Interaction Trace`, `# aGiT Metadata` — with `## User` / `## Agent` subsections inside the interaction trace. Commits are written with `git commit -F -` (no editor), so the `#` lines are preserved rather than stripped as git comments. Secrets and terminal escape sequences are masked out of subjects and trace bodies before committing.
+aGiT commit messages use a consistent Markdown-style structure. The first line is the subject (prefixed with `<aGiT>` for agent commits — including the cover commits placed on top of backend-made commits — `<aGiT-merge>` for agent-resolved merges, or left plain for user commits). When summarization is enabled the summary leads the message: its first line is the subject and the rest is the first paragraph of the body. The rest of the body is organized into `#` sections — `# Prompts` (when a summary takes the subject), `# Interaction Trace`, `# aGiT Metadata` — with `## User` / `## Agent` subsections inside the interaction trace. Commits are written with `git commit -F -` (no editor), so the `#` lines are preserved rather than stripped as git comments. Secrets and terminal escape sequences are masked out of subjects and trace bodies before committing.
 
 Because the conversation is recorded in commit messages, aGiT shows a privacy warning at startup — never enter passwords, API keys, or other sensitive information in the chat — which must be acknowledged to continue (skipped when there is no terminal to acknowledge from).
 
@@ -180,7 +180,7 @@ The status bar shows whether summarization is active (`sum:on` / `sum:off`). Use
 - Proxy mode preserves the backend's selected model in commit metadata when it can be read from session data.
 - User commits use the user-provided subject and include aGiT metadata.
 - Commits are created only when staged changes exist.
-- If the backend commits on its own (e.g. the agent runs `git commit` itself, or a hook does), aGiT amends the latest of those commits once the turn finishes, appending the interaction trace and metadata so provenance is not lost. The `covered_commits` metadata line records the original (pre-amend) hashes of every backend-made commit the metadata accounts for; when aGiT also has uncommitted changes to commit, its own commit carries that line instead. Only commits not yet integrated into the base branch are ever amended.
+- If the backend commits on its own (e.g. the agent runs `git commit` itself, or a hook does), aGiT never rewrites those commits — their hashes stay exactly what the agent may already have reported in PR or issue comments. Instead, once the turn finishes, aGiT adds a *cover commit* on top carrying the interaction trace and metadata: a merge-shaped commit in the GitHub PR merge style, whose tree is the backend head's tree and whose parents are the turn's start and the backend's head, so `git log --first-parent` reads turn-by-turn while the backend's own commits remain reachable via the second parent. The `covered_commits` metadata line records the hashes of the backend-made commits the cover accounts for; when aGiT also has uncommitted changes to commit, its own (regular) commit carries that line instead.
 ## Advanced Usage
 
 Show aGiT diagnostic messages:
@@ -263,7 +263,6 @@ User-wide settings live in `~/.agit/config.json` (override the directory with `A
   "menu_key": "ctrl-g",
   "sandbox": true,
   "use_worktrees": true,
-  "tag_backend_commits": true,
   "timings": {
     "base_poll_seconds": 3.0
   }
@@ -275,8 +274,6 @@ User-wide settings live in `~/.agit/config.json` (override the directory with `A
 `sandbox` (default `true`) confines the agent's writes to its own session worktree (via `sandbox-exec` on macOS), keeping the base repository and sibling worktrees read-only to the agent. Set it to `false` to disable confinement; when sandboxing is unavailable, aGiT instead warns when the base repository is edited while a session runs.
 
 `use_worktrees` (default `true`) controls whether sessions run in isolated worktrees. Set it to `false` to run the agent directly on the current branch by default — the same behavior as `--no-worktree` (which always wins over the config). See the `--no-worktree` notes under Usage for the trade-offs.
-
-`tag_backend_commits` (default `true`) prefixes the subject of commits the backend made itself with `<aGiT>` when aGiT amends them to attach its interaction trace and metadata, so the log shows which commits were backend-made and aGiT-amended. Set it to `false` to keep the backend's original subject untouched (the trace/metadata are still appended to the message body either way).
 
 `menu_key` sets the key that opens aGiT's command menu in proxy mode. The default is `ctrl-g`; any `ctrl-<letter>` works except keys the terminal or aGiT already uses (`ctrl-c` exit flow, `ctrl-h` Backspace, `ctrl-i` Tab, `ctrl-j`/`ctrl-m` Enter). An invalid value falls back to `ctrl-g`, so a typo can never lock you out of the menu. The status line and aGiT's messages show whichever key is configured.
 

--- a/agit/commits/__init__.py
+++ b/agit/commits/__init__.py
@@ -7,7 +7,6 @@ from agit.commits.message import (
     apply_summary_to_message,
     build_agent_commit_message,
     build_agent_merge_message,
-    build_backend_amend_message,
     build_user_commit_message,
     summary_metadata_lines,
 )
@@ -18,7 +17,6 @@ __all__ = [
     "apply_summary_to_message",
     "build_agent_commit_message",
     "build_agent_merge_message",
-    "build_backend_amend_message",
     "build_user_commit_message",
     "summary_metadata_lines",
 ]

--- a/agit/commits/message.py
+++ b/agit/commits/message.py
@@ -11,10 +11,9 @@ DEFAULT_SUBJECT = "No subject provided"
 # whole subject line (prefix included) to that limit so it's never cut off.
 MAX_SUBJECT_WIDTH = 72
 MAX_BODY_WIDTH = 72
-# Subject tag for agent commits: commits aGiT creates from the agent's work
-# AND backend-made commits aGiT amends with its trace/metadata (issue #35).
-# For amended backend commits the tag is removable via the
-# "tag_backend_commits" config option (on by default).
+# Subject tag for agent commits: every commit aGiT creates from the agent's
+# work, including the cover commits placed on top of backend-made commits to
+# carry their trace/metadata (issues #35/#58).
 AGIT_SUBJECT_PREFIX = "<aGiT> "
 SECRET_MASK = "[REDACTED]"
 SECRET_ASSIGNMENT_RE = re.compile(
@@ -175,57 +174,6 @@ def _insert_before_version_line(lines: list[str], extra: list[str]) -> list[str]
     return lines + list(extra)
 
 
-def build_backend_amend_message(
-    *,
-    original_message: str,
-    trace: list[dict],
-    backend: str,
-    backend_session_id: str | None,
-    agit_session_id: str,
-    model: str | None,
-    token_usage: dict[str, int | None] | None = None,
-    trace_turn_limit: int = 5,
-    session_name: str | None = None,
-    covered_commits: list[str] | None = None,
-    tag: bool = True,
-) -> str:
-    """Message for amending a commit the backend made itself (issue #35).
-
-    Keeps the backend's own subject and body, prefixing the subject with
-    ``<aGiT> `` (unless *tag* is False — the ``tag_backend_commits`` config
-    option) so the log shows the commit was backend-made and aGiT-amended,
-    then appends the interaction trace and aGiT metadata.
-    ``covered_commits`` records the pre-amend hashes of every backend-made
-    commit this metadata accounts for — the amended commit itself plus any
-    earlier ones in the same turn.
-    """
-    original = _mask_secrets(original_message).strip()
-    subject, _, body = original.partition("\n")
-    if not subject.strip():
-        subject = DEFAULT_SUBJECT
-    already_tagged = subject.strip().startswith(AGIT_SUBJECT_PREFIX.strip())
-    if tag and not already_tagged:
-        subject = f"{AGIT_SUBJECT_PREFIX}{subject.strip()}"
-    lines = [subject]
-    if body.strip():
-        lines.extend(["", body.strip()])
-    lines.append("")
-    lines.extend(
-        _trace_and_metadata_lines(
-            trace=trace,
-            backend=backend,
-            backend_session_id=backend_session_id,
-            agit_session_id=agit_session_id,
-            model=model,
-            token_usage=token_usage,
-            trace_turn_limit=trace_turn_limit,
-            session_name=session_name,
-            covered_commits=covered_commits,
-        )
-    )
-    return "\n".join(lines).rstrip() + "\n"
-
-
 def _trace_and_metadata_lines(
     *,
     trace: list[dict],
@@ -264,8 +212,8 @@ def _trace_and_metadata_lines(
         ]
     )
     if covered_commits:
-        # Which commit hashes this trace/metadata accounts for (issue #35).
-        # For an amended backend commit the hash listed is its pre-amend id.
+        # The backend-made commits this trace/metadata accounts for (#35).
+        # Those commits are never rewritten, so the hashes stay valid (#58).
         lines.append(f"covered_commits: {' '.join(covered_commits)}")
     lines.extend(_token_metadata_lines(token_usage))
     if summary_metadata:

--- a/agit/config/settings.py
+++ b/agit/config/settings.py
@@ -138,19 +138,6 @@ class GlobalConfig:
         return result
 
     @property
-    def tag_backend_commits(self) -> bool:
-        # Prefix commits the backend made itself with "<aGiT> " when aGiT
-        # amends them with its trace/metadata (issue #35). On by default; set
-        # "tag_backend_commits": false to keep the backend's subject untouched.
-        value = self.data.get("tag_backend_commits")
-        return True if value is None else bool(value)
-
-    @tag_backend_commits.setter
-    def tag_backend_commits(self, value: bool) -> None:
-        self.data["tag_backend_commits"] = bool(value)
-        self.save()
-
-    @property
     def summarization_model(self) -> str | None:
         value = self.data.get("summarization_model")
         return str(value) if value else None

--- a/agit/git/repo.py
+++ b/agit/git/repo.py
@@ -116,6 +116,26 @@ class GitRepo:
         self._run(["git", "commit", "--amend", "-F", "-"], input_text=message)
         return self.short_sha("HEAD")
 
+    def cover_commit(self, message: str, *, first_parent: str, second_parent: str) -> str:
+        """Create a merge-shaped *cover* commit: the tree of ``second_parent``
+        with parents ``(first_parent, second_parent)`` — the same shape as a
+        GitHub PR merge commit. Used to attach aGiT's message on top of
+        backend-made commits without amending them, since an amend changes
+        their hashes and breaks references already published elsewhere (#58).
+        The checked-out branch (or detached HEAD) moves to the new commit; the
+        working tree is untouched because the tree is identical to HEAD's."""
+        tree = self.rev_parse(f"{second_parent}^{{tree}}")
+        sha = self._run(
+            ["git", "commit-tree", tree, "-p", first_parent, "-p", second_parent],
+            input_text=message,
+        ).stdout.strip()
+        self._run(["git", "reset", "--soft", sha])
+        return self.short_sha(sha)
+
+    def parents(self, ref: str = "HEAD") -> list[str]:
+        output = self._run(["git", "rev-list", "--parents", "-1", ref]).stdout.split()
+        return output[1:]
+
     def short_sha(self, ref: str = "HEAD") -> str:
         return self._run(["git", "rev-parse", "--short", ref]).stdout.strip()
 

--- a/agit/proxy/commit_engine.py
+++ b/agit/proxy/commit_engine.py
@@ -69,7 +69,7 @@ import threading
 import time
 from typing import Callable
 
-from agit.commits import build_agent_commit_message, build_backend_amend_message
+from agit.commits import build_agent_commit_message
 from agit.git import GitRepo
 from agit.transcripts.opencode import SessionTurn
 from agit.transcripts import turns_after
@@ -159,7 +159,6 @@ class CommitEngine:
         session_name: str | None = None,
         accumulate_trace_only_on_commit: bool = False,
         backend_commits: list[str] | None = None,
-        tag_backend_commits: bool = True,
     ) -> bool:
         """Core of every agent-commit path.
 
@@ -187,13 +186,11 @@ class CommitEngine:
             the pending-user-merging logic can run even on failed attempts.
         backend_commits:
             Unintegrated commits the backend made itself this turn (full SHAs,
-            oldest first), issue #35.  With nothing staged, the latest of them
-            is amended to carry the trace/metadata; with staged changes, the
-            normal commit lists them in its ``covered_commits`` metadata.
-        tag_backend_commits:
-            Prefix an amended backend commit's subject with ``<aGiT> ``
-            (issue #35; the ``tag_backend_commits`` config option, on by
-            default).
+            oldest first), issue #35.  With nothing staged, a merge-shaped
+            *cover commit* carrying the trace/metadata is added on top of them
+            (their hashes never change — an amend would break references the
+            agent already published, #58); with staged changes, the normal
+            commit lists them in its ``covered_commits`` metadata.
 
         Commits are created immediately, without any LLM call: summarization
         runs in the background afterwards and is attached by amending the
@@ -216,12 +213,12 @@ class CommitEngine:
                 pre_commit_fn()
             self.repo.add_tracked()
             stage_untracked_fn(self.repo, self.state)
-            amend_backend_head = False
+            cover_backend_head = False
             if not self.repo.has_staged_changes():
-                if not self._head_is_amendable(backend_commits):
+                if not self._head_is_coverable(backend_commits):
                     return False
-                amend_backend_head = True
-            # Commit (or amend) will happen: accumulate trace and tokens now.
+                cover_backend_head = True
+            # Commit (or cover) will happen: accumulate trace and tokens now.
             for turn in turns:
                 if turn.user_prompt:
                     self.state.append_trace("user", turn.user_prompt)
@@ -289,58 +286,49 @@ class CommitEngine:
             self.repo.add_tracked()
             stage_untracked_fn(self.repo, self.state)
 
-            amend_backend_head = False
+            cover_backend_head = False
             if not self.repo.has_staged_changes():
-                if not self._head_is_amendable(backend_commits):
+                if not self._head_is_coverable(backend_commits):
                     return False
-                amend_backend_head = True
+                cover_backend_head = True
 
-            # Accumulate tokens only once we know the commit (or amend) will happen.
+            # Accumulate tokens only once we know the commit (or cover) will happen.
             for turn in turns:
                 self.state.add_token_usage(turn.tokens)
 
             subject_text = " / ".join(subject_prompts) if subject_prompts else f"{backend} changes"
 
         # The metadata lists covered hashes in short form (the full SHAs stay
-        # internal — _head_is_amendable compares them against rev-parse HEAD).
+        # internal — _head_is_coverable compares them against rev-parse HEAD).
+        # An aGiT commit accounts for itself; it lists only the backend-made
+        # commits it additionally covers (#35).
         covered_display = [self._short_sha(sha) for sha in backend_commits]
-        if amend_backend_head:
-            # The backend committed its own work, leaving the tree clean (#35):
-            # amend its latest commit so the trace/metadata land on the commit
-            # that made the change. The covered_commits metadata records the
-            # pre-amend hashes of every backend commit this turn produced.
-            commit_sha = self.repo.amend_commit(
-                build_backend_amend_message(
-                    original_message=self.repo.commit_message("HEAD"),
-                    trace=self.state.pending_trace(),
-                    backend=backend,
-                    backend_session_id=backend_session_id,
-                    agit_session_id=self.state.session_id,
-                    model=model or self.state.model,
-                    token_usage=self.state.pending_token_usage(),
-                    trace_turn_limit=self.state.trace_turn_limit,
-                    session_name=session_name,
-                    covered_commits=covered_display,
-                    tag=tag_backend_commits,
-                )
+        message = build_agent_commit_message(
+            latest_prompt=subject_text,
+            trace=self.state.pending_trace(),
+            backend=backend,
+            backend_session_id=backend_session_id,
+            agit_session_id=self.state.session_id,
+            model=model or self.state.model,
+            token_usage=self.state.pending_token_usage(),
+            trace_turn_limit=self.state.trace_turn_limit,
+            session_name=session_name,
+            covered_commits=covered_display or None,
+        )
+        if cover_backend_head:
+            # The backend committed its own work, leaving the tree clean (#35).
+            # Its commits keep their hashes — amending them broke references
+            # the agent had already published in PRs/issues (#58). Instead the
+            # trace/metadata ride a GitHub-PR-style merge-shaped cover commit
+            # on top: same tree as the backend's head, parents (turn start,
+            # backend head), so `git log --first-parent` reads turn-by-turn.
+            commit_sha = self.repo.cover_commit(
+                message,
+                first_parent=f"{backend_commits[0]}^",
+                second_parent=backend_commits[-1],
             )
         else:
-            commit_sha = self.repo.commit(
-                build_agent_commit_message(
-                    latest_prompt=subject_text,
-                    trace=self.state.pending_trace(),
-                    backend=backend,
-                    backend_session_id=backend_session_id,
-                    agit_session_id=self.state.session_id,
-                    model=model or self.state.model,
-                    token_usage=self.state.pending_token_usage(),
-                    trace_turn_limit=self.state.trace_turn_limit,
-                    session_name=session_name,
-                    # An aGiT commit accounts for itself; list only the
-                    # backend-made commits it additionally covers (#35).
-                    covered_commits=covered_display or None,
-                )
-            )
+            commit_sha = self.repo.commit(message)
         self.state.clear_trace()
 
         if on_commit_fn is not None:
@@ -356,18 +344,19 @@ class CommitEngine:
         except Exception:
             return sha[:7]
 
-    def _head_is_amendable(self, backend_commits: list[str]) -> bool:
+    def _head_is_coverable(self, backend_commits: list[str]) -> bool:
         """True when HEAD is the latest of the backend's own unintegrated
-        commits, so amending it attaches the trace to the commit that actually
-        made the change (#35). Never true for commits aGiT created (they carry
-        their own metadata) or for anything already integrated into base
-        (``backend_commits`` only ever lists commits ahead of base)."""
+        commits, so a cover commit on top attaches the trace to the commits
+        that actually made the change (#35). Never true for commits aGiT
+        created (they carry their own metadata) or for anything already
+        integrated into base (``backend_commits`` only ever lists commits
+        ahead of base)."""
         if not backend_commits:
             return False
         try:
             return self.repo.rev_parse("HEAD") == backend_commits[-1]
         except Exception as error:
-            self._debug(f"amend check failed: {error!r}")
+            self._debug(f"cover check failed: {error!r}")
             return False
 
     # ------------------------------------------------------------------

--- a/agit/proxy/runner.py
+++ b/agit/proxy/runner.py
@@ -3384,24 +3384,30 @@ class ProxyRunner:
             on_commit_fn=on_commit_fn,
             session_name=self.name,
             backend_commits=self._uncovered_backend_commits(),
-            tag_backend_commits=getattr(self.global_config, "tag_backend_commits", True)
-            if self.global_config is not None
-            else True,
         )
 
     def _uncovered_backend_commits(self) -> list[str]:
         """Unintegrated commits on the session's turn branch that the backend
-        created itself — their messages carry no aGiT metadata (#35). Full
-        SHAs, oldest first. Only commits ahead of base qualify, so an amend
-        can never rewrite anything that was already integrated."""
+        created itself and no aGiT commit accounts for yet (#35). Full SHAs,
+        oldest first. Backend commits keep their own messages forever (their
+        hashes must stay stable, #58), so "covered" cannot be read off the
+        commit itself: an aGiT metadata commit covers everything before it on
+        the branch (its ``covered_commits`` named them), leaving only commits
+        NEWER than the newest metadata commit unaccounted for. Only commits
+        ahead of base qualify at all."""
         if self.worktree is None or self._base_branch is None:
             return []
         try:
             branch = self.repo.current_branch()
             if not branch.startswith("agit/"):
                 return []
-            shas = self.repo.log_shas(self._base_branch, branch)
-            return [sha for sha in shas if METADATA_HEADER not in self.repo.commit_message(sha)]
+            uncovered: list[str] = []
+            for sha in self.repo.log_shas(self._base_branch, branch):  # oldest first
+                if METADATA_HEADER in self.repo.commit_message(sha):
+                    uncovered = []
+                else:
+                    uncovered.append(sha)
+            return uncovered
         except Exception as error:
             self._debug(f"uncovered backend commit check failed: {error!r}")
             return []

--- a/tests/test_backend_commits.py
+++ b/tests/test_backend_commits.py
@@ -1,18 +1,21 @@
-"""Backend-made commits get aGiT's trace/metadata attached (issue #35).
+"""Backend-made commits get aGiT's trace/metadata attached (issues #35, #58).
 
 Some backends commit on their own (a Claude Code hook, or an agent told to run
 `git commit`). Those commits leave the worktree clean, so aGiT's normal
-stage-and-commit path never runs and the turn's provenance was lost. Option A
-(decided on the issue): amend the backend's latest commit with the interaction
-trace and metadata; the metadata's ``covered_commits`` line records the
-pre-amend hashes of every commit it accounts for.
+stage-and-commit path never runs and the turn's provenance was lost.
+
+Amending the backend's latest commit (the original #35 fix) changed its hash,
+which broke references the agent had already published in PRs and issues
+(#58). The trace/metadata now ride a *cover commit* instead — the GitHub PR
+merge-commit shape: tree of the backend's head, parents (turn start, backend
+head) — so every backend-made hash stays exactly what the agent reported.
 """
 
 from pathlib import Path
 from types import SimpleNamespace
 
 from agit.backends.base import TokenUsage
-from agit.commits import build_agent_commit_message, build_backend_amend_message
+from agit.commits import build_agent_commit_message
 from agit.config import AgitState
 from agit.git import GitRepo
 from agit.proxy.commit_engine import CommitEngine
@@ -63,60 +66,7 @@ def _commit_turns(repo: GitRepo, state: AgitState, backend_commits: list[str], *
     )
 
 
-# --- message builders --------------------------------------------------------
-
-
-def test_amend_message_keeps_original_and_appends_trace_and_metadata():
-    message = build_backend_amend_message(
-        original_message="fix the parser\n\nDetails the agent wrote itself.",
-        trace=[{"role": "user", "content": "fix it"}, {"role": "agent", "content": "fixed"}],
-        backend="claude",
-        backend_session_id="ses-1",
-        agit_session_id="agit-1",
-        model="m1",
-        session_name="s1",
-        covered_commits=["abc123", "def456"],
-    )
-    assert message.startswith("<aGiT> fix the parser\n")
-    assert "Details the agent wrote itself." in message
-    assert "# Interaction Trace" in message
-    assert "## User" in message and "fix it" in message
-    assert "# aGiT Metadata" in message
-    assert "commit_type: agent" in message
-    assert "covered_commits: abc123 def456" in message
-
-
-def test_amend_message_does_not_double_prefix_subject():
-    message = build_backend_amend_message(
-        original_message="<aGiT> already prefixed",
-        trace=[],
-        backend="claude",
-        backend_session_id=None,
-        agit_session_id="agit-1",
-        model=None,
-        covered_commits=["abc123"],
-    )
-    assert message.startswith("<aGiT> already prefixed\n")
-    assert "<aGiT> <aGiT>" not in message
-
-
-def test_amend_message_tag_can_be_disabled():
-    # The tag_backend_commits config option (README: default true) removes the
-    # <aGiT> subject tag while keeping the trace/metadata in the body.
-    message = build_backend_amend_message(
-        original_message="fix the parser",
-        trace=[{"role": "user", "content": "fix it"}],
-        backend="claude",
-        backend_session_id=None,
-        agit_session_id="agit-1",
-        model=None,
-        covered_commits=["abc123"],
-        tag=False,
-    )
-    assert message.startswith("fix the parser\n")
-    assert "<aGiT>" not in message
-    assert "# aGiT Metadata" in message
-    assert "covered_commits: abc123" in message
+# --- message builder ----------------------------------------------------------
 
 
 def test_agent_commit_message_covered_commits_line():
@@ -134,28 +84,50 @@ def test_agent_commit_message_covered_commits_line():
     assert "covered_commits" not in without
 
 
-# --- commit_turns amend path -------------------------------------------------
+# --- commit_turns cover path ---------------------------------------------------
 
 
-def test_clean_tree_amends_latest_backend_commit(tmp_path):
+def test_clean_tree_covers_backend_commits_without_rewriting_them(tmp_path):
     repo, _base = _repo_on_turn_branch(tmp_path)
     state = AgitState(tmp_path)
+    turn_start = repo.rev_parse("HEAD")
     first = _backend_commit(repo, "a.txt", "backend commit one")
     last = _backend_commit(repo, "b.txt", "backend commit two")
 
     committed = _commit_turns(repo, state, [first, last])
 
     assert committed is True
+    # The backend's commits keep their hashes AND their messages (#58): any
+    # reference the agent published (PR/issue comments) stays valid.
+    assert repo.rev_parse("HEAD^2") == last
+    assert repo.commit_message(first).startswith("backend commit one")
+    assert repo.commit_message(last).startswith("backend commit two")
+    # The cover commit is merge-shaped, GitHub-PR style: parents are the turn
+    # start and the backend's head, and its tree is the backend head's tree.
+    assert repo.parents("HEAD") == [turn_start, last]
+    assert repo.rev_parse("HEAD^{tree}") == repo.rev_parse(f"{last}^{{tree}}")
     head_message = repo.commit_message("HEAD")
-    assert head_message.startswith("<aGiT> backend commit two")
+    assert head_message.startswith("<aGiT> add the feature")
     assert "# Interaction Trace" in head_message
-    assert "add the feature" in head_message
-    # Covered hashes are recorded in SHORT form, the amended commit included.
     assert f"covered_commits: {repo.short_sha(first)} {repo.short_sha(last)}" in head_message
-    assert repo.rev_parse("HEAD") != last  # amend rewrote the hash
-    # The earlier backend commit is untouched (only HEAD may be amended).
-    assert repo.commit_message("HEAD^").startswith("backend commit one")
-    assert state.pending_trace() == []  # trace consumed by the amend
+    assert state.pending_trace() == []  # trace consumed by the cover commit
+
+
+def test_cover_commit_makes_first_parent_log_turn_level(tmp_path):
+    # `git log --first-parent` on the branch reads turn-by-turn: one aGiT
+    # cover commit, with the backend's commits reachable via the second parent.
+    repo, base = _repo_on_turn_branch(tmp_path)
+    state = AgitState(tmp_path)
+    first = _backend_commit(repo, "a.txt", "backend commit one")
+    last = _backend_commit(repo, "b.txt", "backend commit two")
+
+    assert _commit_turns(repo, state, [first, last]) is True
+
+    output = repo._run(
+        ["git", "log", "--first-parent", "--format=%s", f"{base}..HEAD"],
+    ).stdout.splitlines()
+    assert len(output) == 1
+    assert output[0].startswith("<aGiT> add the feature")
 
 
 def test_clean_tree_without_backend_commits_does_not_commit(tmp_path):
@@ -167,9 +139,9 @@ def test_clean_tree_without_backend_commits_does_not_commit(tmp_path):
     assert repo.rev_parse("HEAD") == head
 
 
-def test_amend_refused_when_head_is_not_the_latest_backend_commit(tmp_path):
-    # An aGiT commit sits on top of the backend's: amending would rewrite
-    # aGiT's own commit, so the engine must refuse.
+def test_cover_refused_when_head_is_not_the_latest_backend_commit(tmp_path):
+    # An aGiT commit sits on top of the backend's: it already accounts for the
+    # turn, so the engine must not stack another cover commit.
     repo, _base = _repo_on_turn_branch(tmp_path)
     state = AgitState(tmp_path)
     backend_sha = _backend_commit(repo, "a.txt", "backend commit")
@@ -198,41 +170,27 @@ def test_staged_changes_commit_lists_backend_commits_as_covered(tmp_path):
     assert repo.commit_message("HEAD^").startswith("backend commit")
 
 
-def test_commit_turns_honors_tag_backend_commits_off(tmp_path):
-    repo, _base = _repo_on_turn_branch(tmp_path)
-    state = AgitState(tmp_path)
-    sha = _backend_commit(repo, "a.txt", "backend commit")
-
-    committed = _commit_turns(repo, state, [sha], tag_backend_commits=False)
-
-    assert committed is True
-    head_message = repo.commit_message("HEAD")
-    assert head_message.startswith("backend commit\n")
-    assert "<aGiT>" not in head_message
-    assert f"covered_commits: {repo.short_sha(sha)}" in head_message  # metadata still attached
-
-
-def test_summary_amend_preserves_agit_tag():
-    # When a summary is later amended into an amended backend commit, the
-    # subject keeps its <aGiT> tag instead of being relabeled <aGiT>.
+def test_cover_commit_survives_summary_amend_with_parents_intact(tmp_path):
+    # The async summary (#8) amends the COVER commit — aGiT's own commit,
+    # created moments earlier — never the backend's. The amend keeps the merge
+    # shape, so the backend hashes stay reachable and stable.
     from agit.commits import apply_summary_to_message
 
-    message = build_backend_amend_message(
-        original_message="fix the parser",
-        trace=[{"role": "user", "content": "fix it"}],
-        backend="claude",
-        backend_session_id=None,
-        agit_session_id="agit-1",
-        model=None,
-        covered_commits=["abc123"],
-    )
-    summarized = apply_summary_to_message(message, "Rework the parser error paths")
-    assert summarized.startswith("<aGiT> Rework the parser error paths\n")
-    # The original subject is preserved under # Prompts, without its tag.
-    assert "fix the parser" in summarized.split("# Prompts")[1]
+    repo, _base = _repo_on_turn_branch(tmp_path)
+    state = AgitState(tmp_path)
+    turn_start = repo.rev_parse("HEAD")
+    backend_sha = _backend_commit(repo, "a.txt", "backend commit")
+    assert _commit_turns(repo, state, [backend_sha]) is True
+
+    message = repo.commit_message("HEAD")
+    repo.amend_commit(apply_summary_to_message(message, "Rework the parser error paths"))
+
+    assert repo.commit_message("HEAD").startswith("<aGiT> Rework the parser error paths")
+    assert repo.parents("HEAD") == [turn_start, backend_sha]
+    assert repo.commit_message(backend_sha).startswith("backend commit")
 
 
-def test_amend_in_actions_mode_accumulates_trace_first(tmp_path):
+def test_cover_in_actions_mode_accumulates_trace_first(tmp_path):
     repo, _base = _repo_on_turn_branch(tmp_path)
     state = AgitState(tmp_path)
     sha = _backend_commit(repo, "a.txt", "backend commit")
@@ -261,12 +219,26 @@ def _detection_runner(tmp_path):
     return runner, repo
 
 
-def test_uncovered_backend_commits_detects_only_unmarked_commits(tmp_path):
+def test_uncovered_backend_commits_detects_commits_after_last_agit_commit(tmp_path):
     runner, repo = _detection_runner(tmp_path)
-    plain = _backend_commit(repo, "a.txt", "backend's own commit")
-    _backend_commit(repo, "b.txt", AGIT_BODY)  # has metadata: covered
+    _backend_commit(repo, "a.txt", "covered by the aGiT commit after it")
+    _backend_commit(repo, "b.txt", AGIT_BODY)  # an aGiT commit covers everything before it
+    plain = _backend_commit(repo, "c.txt", "backend's own commit, not yet covered")
 
     assert runner._uncovered_backend_commits() == [plain]
+
+
+def test_uncovered_backend_commits_empty_after_cover_commit(tmp_path):
+    # Backend commits keep their metadata-less messages forever (#58), so the
+    # detector must not re-report them once a cover commit accounts for them —
+    # even while integration is still pending.
+    runner, repo = _detection_runner(tmp_path)
+    state = AgitState(tmp_path)
+    first = _backend_commit(repo, "a.txt", "backend commit one")
+    last = _backend_commit(repo, "b.txt", "backend commit two")
+    assert _commit_turns(repo, state, [first, last]) is True
+
+    assert runner._uncovered_backend_commits() == []
 
 
 def test_uncovered_backend_commits_empty_off_turn_branch(tmp_path):
@@ -280,7 +252,7 @@ def test_uncovered_backend_commits_empty_off_turn_branch(tmp_path):
 def test_uncovered_backend_commits_empty_without_worktree(tmp_path):
     runner, repo = _detection_runner(tmp_path)
     _backend_commit(repo, "a.txt", "backend's own commit")
-    runner.worktree = None  # --no-worktree mode: never amend the user's branch
+    runner.worktree = None  # --no-worktree mode: never touch the user's branch
 
     assert runner._uncovered_backend_commits() == []
 
@@ -312,7 +284,7 @@ def test_attach_defers_integration_while_parse_pending():
     assert runner.calls.started == 1  # kicked off the parse that will attach
 
 
-def test_attach_proceeds_after_amend():
+def test_attach_proceeds_after_cover():
     runner = _attach_runner(["abc"])
     runner._finish_agent_parse_if_ready = lambda **kw: True
     assert runner._attach_trace_to_backend_commits(100.0) is True

--- a/tests/test_backends_and_config.py
+++ b/tests/test_backends_and_config.py
@@ -243,17 +243,3 @@ def test_use_worktrees_config_opt_out(tmp_path, monkeypatch):
     monkeypatch.setenv("AGIT_CONFIG_DIR", str(tmp_path))
     (tmp_path / "config.json").write_text('{"use_worktrees": false}')
     assert GlobalConfig().use_worktrees is False
-
-
-def test_tag_backend_commits_defaults_true(tmp_path):
-    config = GlobalConfig(tmp_path / "config.json")
-    assert config.tag_backend_commits is True
-
-
-def test_tag_backend_commits_opt_out_round_trips(tmp_path):
-    path = tmp_path / "config.json"
-    config = GlobalConfig(path)
-    config.tag_backend_commits = False
-    assert GlobalConfig(path).tag_backend_commits is False
-    config.tag_backend_commits = True
-    assert GlobalConfig(path).tag_backend_commits is True


### PR DESCRIPTION
This session resolved aGiT issue #58: when the backend agent made its own commits during a turn, aGiT previously attached its interaction trace and metadata by amending the backend's latest commit, which rewrote that commit's hash and broke references the agent had already published (e.g., commit SHAs cited in PR or issue comments). Since a git
 commit's id hashes its message and parents, any metadata-appending
rewrite necessarily mints a new id; the only hash-stable alternatives were git-notes (invisible on GitHub, not pushed by default) or recording
 metadata in a new commit on top. The session chose the latter, modeled
directly on GitHub's PR merge-commit mechanism.

The core change replaces the amend path in `CommitEngine.commit_turns` with a "cover commit": when a turn ends with a clean tree and unintegrated backend commits B1..Bn, a new `GitRepo.cover_commit` method
 uses `git commit-tree` to create a merge-shaped commit whose tree is
Bn's tree and whose parents are (turn start, Bn), then moves the branch via `git reset --soft`. The first parent is derived as `backend_commits[0]^` — the turn's start point — so no pre-created branch is needed. The cover carries the standard `<aGiT>` message (trace, metadata, `covered_commits: B1..Bn`), built with the existing `build_agent_commit_message` rather than a dedicated builder. Backend commits stay byte-identical, and `git log --first-parent` now reads turn-by-turn with intra-turn backend commits reachable via the second parent.

Several consequential changes fell out of the design. `build_backend_amend_message` and the `tag_backend_commits` config option (with its `GlobalConfig` property and README docs) were deleted entirely — with no amend, there is no backend subject to tag. `_head_is_amendable` was renamed `_head_is_coverable` with unchanged logic (HEAD must be the latest backend commit; never true when an aGiT commit already sits on top). Most subtly, `_uncovered_backend_commits` in `ProxyRunner` had to change semantics: it previously identified covered commits by checking for aGiT metadata in commit messages, but backend commits now stay metadata-less forever. The detector now treats an aGiT metadata commit as covering everything before it on the turn branch, resetting its accumulator when it encounters one and reporting only commits newer than the newest metadata commit. This also fixed a latent bug where earlier same-turn backend commits could be double- counted while integration was pending.

The async summarization path was deliberately left amending — but it only ever amends the cover commit (aGiT's own, seconds old, never externally referenced), and `git commit --amend` preserves merge parents, which a new test pins
(`test_cover_commit_survives_summary_amend_with_parents_intact` asserts parents remain (turn start, backend head) after the summary amend). Other new tests pin the merge shape and tree identity, the stability of backend hashes and messages, the turn-level first-parent log, and the new covered-detection semantics including the empty-after-cover case. A `GitRepo.parents` helper was added to support these assertions. Trade- off accepted: the history gains one merge-shaped commit per backend- committing turn, and "covered" status is now positional (inferred from branch topology) rather than self-describing in each commit's message.

# Prompts

Cover backend-made commits with a merge commit instead of amending (#58)

Amending the backend's latest commit to attach the interaction trace/metadata (#35) changed its hash, which broke references the agent had already published — PR comments, issue comments, or its own final response naming the SHA.

Backend-made commits are now never rewritten. When a turn ends with the tree clean and backend-made commits present, aGiT adds a *cover commit* on top in the GitHub PR merge style: the tree of the backend's head with parents (turn start, backend head). The cover carries the usual aGiT message (prompt subject, trace, metadata) and lists the backend commits in covered_commits; `git log --first-parent` reads turn-by-turn while the backend's own commits stay reachable — and byte-identical — via the second parent. The async summary still amends only the cover commit (aGiT's own, seconds old), preserving both parents.

Since backend commits now keep their metadata-less messages forever, the uncovered-commit detector no longer keys off each commit's own message: an aGiT metadata commit covers everything before it on the turn branch, so only commits newer than the newest metadata commit count as uncovered. This also fixes a latent double-count: earlier same-turn backend commits (only the latest was amended) could be re-reported while integration was pending.

The tag_backend_commits config and build_backend_amend_message are removed — with no amend there is no backend subject to tag; the cover commit is an aGiT commit and always carries <aGiT>.

Co-Authored-By: Claude Fable 5 <noreply@anthropic.com>

# Interaction Trace

## User

Think about this issue and provide your suggestion in a comment to the
issue: https://github.com/core-aix/agit/issues/58     It seems to me
that when merging a PR with commit merge, it creates a new commit with
all the file changes, while the commits inside the PR and their file
changes still exist before the PR commit. Is this a mechanism that we
can probably implement in aGiT too, or do you have better suggestions?

## Agent

You've hit your session limit · resets 1:10am (Europe/London)

## User

Think about this issue and provide your suggestion in a comment to the
issue: https://github.com/core-aix/agit/issues/58     It seems to me
that when merging a PR with commit merge, it creates a new commit with
all the file changes, while the commits inside the PR and their file
changes still exist before the PR commit. Is this a mechanism that we
can probably implement in aGiT too, or do you have better suggestions?
It seems one option is to create a branch before the first backend
commit, then create a merge commit with an <aGiT> message. Please see
what is possible, and if you have a solution, you can implement it.

## User

It seems one option is to create a branch before the first backend commit, then create a merge commit with an <aGiT> message. Please see what is possible, and if you have a solution, you can implement it.

## Agent

Done — analysis posted on [#58](https://github.com/core- aix/agit/issues/58#issuecomment-4696749866) and the solution implemented
 in `fb9f492` (full gate green).

**The short version of the analysis:** the hash change is unavoidable in
 git — the id hashes the message and parents, so appending metadata
always mints a new id. The only hash-stable designs are git-notes (invisible on GitHub, doesn't push by default) or your suggestion: never
 rewrite, and record the metadata in a commit on top, exactly like a
GitHub PR merge commit. The second is clearly right, so I implemented it.

**What changed:** when a turn ends with a clean tree and backend-made commits `B1..Bn`, aGiT no longer amends `Bn`. It creates a **cover commit** via `git commit-tree` — the tree of `Bn` with parents `(turn start, Bn)`, the exact GitHub merge-commit shape. The cover carries the normal `<aGiT>` message (trace, metadata, `covered_commits: B1..Bn`), and the backend's commits stay byte-identical forever, so any hash the agent posted in a PR or issue remains valid. No branch needs to be created beforehand — the turn's start point already gives us the first parent. A nice side effect: `git log --first-parent` now reads turn-by- turn, with the agent's intra-turn commits behind the second parent.

**Follow-on changes that fell out of it:**
- The uncovered-commit detector can't read "covered" off commit messages anymore (backend commits stay metadata-less), so an aGiT metadata commit now covers everything before it on the turn branch. That also fixed a latent double-count of earlier same-turn backend commits while integration was pending.
- The async summary still amends only the cover commit (aGiT's own, seconds old, never externally referenced) and preserves the merge parents — test-pinned.
- `tag_backend_commits` and `build_backend_amend_message` are gone: with no amend there's no backend subject to tag.

Tests pin the merge shape, stable backend hashes/messages, the turn- level first-parent log, summary-amend parent preservation, and the new covered semantics. The issue stays open for you to verify; the running agit needs a restart to pick this up.

# aGiT Metadata
commit_type: agent
backend: claude
model: claude-fable-5
session_name: session-1
agit_session_id: agit-d65dbebd-0555-40bb-94eb-d8405eb432cf backend_session_id: 0b705918-b550-4ac7-86e4-c73b2612458e covered_commits: fb9f492
context_tokens: 248549
tokens_since_last_commit_input: 839493
tokens_since_last_commit_cache_read: 13639733
tokens_since_last_commit_cache_write: 821753
tokens_since_last_commit_output: 85625
summary_model: claude-fable-5
summary_tokens_input: 3642
summary_tokens_output: 2423
agit_version: 0.0.1