### PR TITLE
Fix release workflow

### DIFF
--- a/.github/workflows/release-patch.yml
+++ b/.github/workflows/release-patch.yml
@@ -7,10 +7,13 @@ on:
 
 permissions:
   contents: write
+  pull-requests: write
 
 jobs:
   release:
     runs-on: ubuntu-latest
+    # Don't react to the bump commit itself. (Merges made with GITHUB_TOKEN do
+    # not trigger workflows, so this is also belt-and-suspenders against a loop.)
     if: github.event.head_commit.author.name != 'github-actions[bot]'
 
     steps:
@@ -31,46 +34,62 @@ jobs:
       - name: Bump patch version
         id: bump
         run: |
-          python3 <<'PY'
+          python3 <<'PY' >> "$GITHUB_OUTPUT"
           import re, pathlib
 
           pp = pathlib.Path("pyproject.toml")
           m = re.search(r'^version = "(\d+)\.(\d+)\.(\d+)"', pp.read_text(), re.M)
           if not m:
               raise SystemExit("could not find version in pyproject.toml")
-          major, minor, patch = int(m.group(1)), int(m.group(2)), int(m.group(3))
-          patch += 1
-          new_version = f"{major}.{minor}.{patch}"
+          major, minor, patch = (int(g) for g in m.groups())
+          new_version = f"{major}.{minor}.{patch + 1}"
 
           pp.write_text(re.sub(
-              r'^version = "[^"]+"',
-              f'version = "{new_version}"',
-              pp.read_text(),
-              count=1,
-              flags=re.M
+              r'^version = "[^"]+"', f'version = "{new_version}"',
+              pp.read_text(), count=1, flags=re.M,
           ))
-
           ip = pathlib.Path("agit/__init__.py")
           ip.write_text(re.sub(
-              r'^__version__ = "[^"]+"',
-              f'__version__ = "{new_version}"',
-              ip.read_text(),
-              count=1,
-              flags=re.M
+              r'^__version__ = "[^"]+"', f'__version__ = "{new_version}"',
+              ip.read_text(), count=1, flags=re.M,
           ))
-
           print(f"version={new_version}")
           PY
 
-      - name: Commit and push
+      - name: Open and merge the version-bump PR
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         run: |
-          VERSION=$(python3 -c "import re; print(re.search(r'version = \"([^\"]+)\"', open('pyproject.toml').read()).group(1))")
+          VERSION="${{ steps.bump.outputs.version }}"
+          BRANCH="release/v${VERSION}"
           git config user.name "github-actions[bot]"
           git config user.email "github-actions[bot]@users.noreply.github.com"
+          git switch -c "$BRANCH"
           git add pyproject.toml agit/__init__.py
           git commit -m "Release v${VERSION}"
-          git tag -a "v${VERSION}" -m "Release v${VERSION}"
-          git push origin main --tags
+          git push origin "$BRANCH"
+          gh pr create --base main --head "$BRANCH" \
+            --title "Release v${VERSION}" \
+            --body "Automated patch version bump to v${VERSION}."
+          # main requires changes via a PR (0 approvals, no required checks), so
+          # the bump PR can be merged straight away. Retry while GitHub is still
+          # computing the PR's mergeable state.
+          for attempt in 1 2 3 4 5 6; do
+            if gh pr merge "$BRANCH" --squash --delete-branch; then
+              merged=1
+              break
+            fi
+            echo "merge attempt ${attempt} failed; retrying in 5s..."
+            sleep 5
+          done
+          if [ "${merged:-0}" != 1 ]; then
+            echo "::error::could not merge the release PR for v${VERSION}"
+            exit 1
+          fi
+          # Build/publish from the merged state.
+          git fetch origin main
+          git switch main
+          git reset --hard origin/main
 
       - name: Build
         run: uv build
@@ -84,8 +103,9 @@ jobs:
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         run: |
-          VERSION=$(python3 -c "import re; print(re.search(r'version = \"([^\"]+)\"', open('pyproject.toml').read()).group(1))")
+          VERSION="${{ steps.bump.outputs.version }}"
           gh release create "v${VERSION}" \
             --title "v${VERSION}" \
+            --target main \
             --generate-notes \
             dist/*

--- a/.github/workflows/release-tag.yml
+++ b/.github/workflows/release-tag.yml
@@ -7,6 +7,7 @@ on:
 
 permissions:
   contents: write
+  pull-requests: write
 
 jobs:
   release:
@@ -61,13 +62,43 @@ jobs:
           ))
           PY
 
-      - name: Commit and push to main
+      - name: Sync version files to main via PR
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         run: |
+          VERSION="${{ steps.version.outputs.version }}"
+          BRANCH="release/sync-v${VERSION}"
           git config user.name "github-actions[bot]"
           git config user.email "github-actions[bot]@users.noreply.github.com"
+          git switch -c "$BRANCH"
           git add pyproject.toml agit/__init__.py
-          git commit -m "Release v${{ steps.version.outputs.version }}"
-          git push origin main
+          # The version files may already match the tag (e.g. the tag was placed
+          # on an already-bumped commit). Only open a PR when there's a change —
+          # main cannot be pushed to directly, so the sync goes through a PR.
+          if git diff --cached --quiet; then
+            echo "Version files already at v${VERSION}; nothing to sync."
+          else
+            git commit -m "Release v${VERSION}"
+            git push origin "$BRANCH"
+            gh pr create --base main --head "$BRANCH" \
+              --title "Release v${VERSION}" \
+              --body "Sync version files to tag v${VERSION}."
+            for attempt in 1 2 3 4 5 6; do
+              if gh pr merge "$BRANCH" --squash --delete-branch; then
+                merged=1
+                break
+              fi
+              echo "merge attempt ${attempt} failed; retrying in 5s..."
+              sleep 5
+            done
+            if [ "${merged:-0}" != 1 ]; then
+              echo "::error::could not merge the version-sync PR for v${VERSION}"
+              exit 1
+            fi
+          fi
+          git fetch origin main
+          git switch main
+          git reset --hard origin/main
 
       - name: Build
         run: uv build


### PR DESCRIPTION
The automated release workflows (`release-patch.yml` and `release- tag.yml`) were failing because they did `git push origin main` directly,
 which is rejected by the repo's `main-branch-protection` ruleset
(`GH013` — "changes must be made through a pull request"). A side effect
 of the failure was an orphaned `v0.0.2` tag pushed to the remote (tags
aren't protected by the ruleset); this orphan tag was deleted so the next release starts clean.

Both workflows were reworked to route version-file changes through a PR- and-merge flow instead of pushing to `main`:

`release-patch.yml`: After bumping the patch version, it now creates a `release/v<version>` branch, pushes it, opens a PR with `gh pr create`, and merges it with `gh pr merge --squash --delete-branch`. It then fetches/resets to `origin/main` before building, publishing to PyPI, and
 creating the GitHub release (now with `--target main`). The bump step
was refactored to write `version=<new>` to `$GITHUB_OUTPUT`, so downstream steps reference `steps.bump.outputs.version` instead of re- parsing `pyproject.toml` each time.

`release-tag.yml`: Had the identical direct-push anti-pattern. Its version-file sync now goes through the same branch/PR/merge flow on a `release/sync-v<version>` branch, but guards with `git diff --cached --quiet` to no-op (skip PR creation) when the version files already match the tag — e.g. when the tag was placed on an already-bumped commit.

Why this works with the ruleset: the PR rule requires 0 approvals and there are no required status checks, so the default `GITHUB_TOKEN` can merge the bot's own PR immediately without admin bypass (the ruleset allows none). Merges/tags created via `GITHUB_TOKEN` don't re-trigger workflows, preventing a release loop; the existing `author != github- actions[bot]` guard was kept as defense-in-depth, and `pull-requests: write` was added to permissions in both files.

Notable details/trade-offs:
- A 6-attempt retry loop (5s sleep) wraps `gh pr merge` to ride out the window where GitHub is still computing the PR's mergeable state; failure
 after all attempts emits `::error::` and exits 1.
- After merging, both workflows do `git fetch origin main` + `git switch main` + `git reset --hard origin/main` to build/publish from the merged squash commit rather than the local branch state.
- Potential first-run risk flagged: if the org/repo has "Allow GitHub Actions to create and approve pull requests" disabled, `gh pr create` could be blocked and that setting would need to be enabled.
- Per standing aGiT instruction, changes were left uncommitted in the worktree (aGiT creates the merge commit); the orphan-tag deletion was a user-approved remote operation. Both YAML files were validated as parseable and the bump script was tested against the real files (0.0.1 →
 0.0.2).

# Prompts

Check the latest failure in automated release workflow. The... Check the latest failure in automated release workflow. The workflow should not push to main directly. Instead, a PR should be created and then merged into main.

# Interaction Trace

## User

Check the latest failure in automated release workflow. The workflow should not push to main directly. Instead, a PR should be created and then merged into main.

## Agent

Orphan tag deleted; no `v*` tags remain on the remote, so the next release gets a clean `v0.0.2`.

## Summary

**Root cause of the failure:** the `main-branch-protection` ruleset requires *"Changes must be made through a pull request,"* but `release- patch.yml` did `git push origin main` directly — rejected with `GH013`. Notably, the failed run still pushed the tag `v0.0.2` (tags aren't protected), leaving an orphan.

**What I changed:**

`release-patch.yml` (the failing workflow) now, instead of pushing to `main`:
1. Bumps the patch version.
2. Creates a `release/v<version>` branch and pushes it.
3. Opens a PR and **merges it** (`gh pr merge --squash`).
4. Builds, publishes to PyPI, and creates the GitHub release on `main`.

`release-tag.yml` had the identical `git push origin main` anti-pattern,
 so I routed its version-file sync through the same PR-and-merge flow
(it no-ops the PR when the files already match the tag).

**Why this works with the ruleset** (I checked it):
- The PR rule requires **0 approvals** and there are **no required status checks**, so the bot can merge its own PR immediately with the default `GITHUB_TOKEN` — no admin bypass needed (the ruleset allows none).
- Merges and tags created via `GITHUB_TOKEN` **don't re-trigger workflows**, so there's no release loop. I also kept the `author != github-actions[bot]` guard as defense-in-depth, and added `pull- requests: write` to permissions.
- Added a short retry loop around `gh pr merge` to ride out the brief window where GitHub is still computing the PR's mergeable state.

I validated both YAML files parse and ran the embedded bump script against the real `pyproject.toml`/`agit/__init__.py` (0.0.1 → 0.0.2, both files updated).

Per the standing aGiT instruction, I did **not** commit — aGiT will create the merge commit. The orphan-tag deletion was a remote operation you approved; everything else is staged in the worktree.

One thing worth your eye on the **first** live run: the `gh pr merge` permission. The default `GITHUB_TOKEN` can merge given this ruleset, but
 if your org has a separate "Allow GitHub Actions to create and approve
pull requests" setting disabled, `gh pr create` could be blocked — in which case you'd flip that org/repo setting on. The mechanics are otherwise sound.

# aGiT Metadata
commit_type: agent
backend: claude
model: claude-opus-4-8
session_name: session-1
agit_session_id: agit-3a8d6e33-cbd9-4fdb-8f9f-d2f9be114c1f backend_session_id: 0b705918-b550-4ac7-86e4-c73b2612458e agent_started_at: 2026-06-13T17:05:01Z
agent_ended_at: 2026-06-13T17:10:06Z
context_tokens: 144184
tokens_since_last_commit_input: 267430
tokens_since_last_commit_cache_read: 3597177
tokens_since_last_commit_cache_write: 266985
tokens_since_last_commit_output: 50201
summary_model: claude-opus-4-8
summary_tokens_input: 3642
summary_tokens_output: 2076
agit_version: 0.0.1