### PR TITLE
fix(proxy): fork a copy when resuming a session held by a running background agent (#114)

### DIFF
--- a/agitrack/backends/proxy_agents.py
+++ b/agitrack/backends/proxy_agents.py
@@ -92,6 +92,7 @@ class ProxyAgent(Protocol):
         *,
         session_id: str | None,
         resume: bool,
+        fork: bool = False,
         commit_guidance: bool = True,
         use_worktrees: bool = True,
         executable: list[str] | None = None,
@@ -179,12 +180,14 @@ class OpenCodeProxyAgent:
         *,
         session_id: str | None,
         resume: bool,
+        fork: bool = False,
         commit_guidance: bool = True,
         use_worktrees: bool = True,
         executable: list[str] | None = None,
     ) -> list[str]:
-        # ``commit_guidance``/``use_worktrees`` are accepted for a uniform interface but
-        # unused: OpenCode's interactive TUI has no flag to append to its system prompt.
+        # ``commit_guidance``/``use_worktrees``/``fork`` are accepted for a uniform
+        # interface but unused: OpenCode's interactive TUI has no flag to append to its
+        # system prompt, and no session-fork concept.
         command = list(executable) if executable else ["opencode"]
         if resume and session_id:
             command.extend(["--session", session_id])
@@ -261,6 +264,7 @@ class ClaudeProxyAgent:
         *,
         session_id: str | None,
         resume: bool,
+        fork: bool = False,
         commit_guidance: bool = True,
         use_worktrees: bool = True,
         executable: list[str] | None = None,
@@ -268,6 +272,10 @@ class ClaudeProxyAgent:
         head = list(executable) if executable else ["claude"]
         if resume and session_id:
             command = [*head, "--resume", session_id]
+            # --fork-session resumes this conversation into a NEW session id, used when
+            # the original is still held by a running background agent (#114).
+            if fork:
+                command.append("--fork-session")
         elif session_id:
             command = [*head, "--session-id", session_id]
         else:

--- a/agitrack/proxy/runner.py
+++ b/agitrack/proxy/runner.py
@@ -124,6 +124,13 @@ def _strip_ansi(text: str) -> str:
     return _ANSI_CSI_OSC_RE.sub("", text).replace("\r", "\n")
 
 
+# The claude CLI refuses to resume a session that is still held by a running
+# background agent, printing this and exiting (e.g. a stale `bg` agent from an
+# earlier run). Its own remedy is --fork-session, which aGiTrack applies
+# automatically rather than crash-looping and exiting (#114).
+_FORK_HINT_RE = re.compile(r"running as a background agent|--fork-session", re.IGNORECASE)
+
+
 # Sentinel: the summarizer-model picker was dismissed (Esc), distinct from a real None choice
 # ("same as the session model"). Lets _choose_summarizer_model report "no change" unambiguously.
 _NO_MODEL_PICK = object()
@@ -542,6 +549,15 @@ class ProxyRunner:
         self.last_child_output = 0.0
         self.last_user_input = 0.0  # monotonic time of the user's last keystroke (drives idle backoff)
         self.last_child_output_sample = b""
+        # Set when the backend exits repeatedly and aGiTrack stops relaunching, so
+        # run() can echo the reason on the restored host screen instead of leaving
+        # the user with a silent flash (#114).
+        self._backend_exit_notice: str | None = None
+        # The claude session we want to resume is held by a running background agent:
+        # fork a copy on the next spawn (claude --fork-session), and remember we did so
+        # we only try once rather than looping (#114).
+        self._fork_next_spawn = False
+        self._forked_for_busy = False
         self.last_status = ""
         self.last_status_change = 0.0
         self.message: str | None = None
@@ -955,6 +971,9 @@ class ProxyRunner:
                 "_backend_command": [],
                 "_commit_guidance": True,
                 "_relaunch_times": [],
+                "_fork_next_spawn": False,
+                "_forked_for_busy": False,
+                "_backend_exit_notice": None,
                 "_exiting": False,
                 "_finalized_on_exit": False,
                 "_exit_aborted": False,
@@ -1136,6 +1155,11 @@ class ProxyRunner:
             # the new instance can acquire it and auto-resume the session.
             if self._reopen_after_exit:
                 self._reopen_in_new_window()
+        # The backend kept exiting on launch and aGiTrack stopped relaunching: the
+        # terminal is restored now, so surface why on the normal screen rather than
+        # exiting with just a flash (#114).
+        if self._backend_exit_notice:
+            print(self._backend_exit_notice)
         # A self-update was applied; re-exec aGiTrack in place now that the terminal
         # is restored and the management lock is released. Does not return.
         if self._pending_restart:
@@ -1170,9 +1194,18 @@ class ProxyRunner:
 
     def _spawn(self) -> None:
         resume = self._should_continue_session()
+        fork = self._fork_next_spawn and resume
+        self._fork_next_spawn = False
         if resume:
             session_id = self.state.backend_session_id
-            self._pre_spawn_session_ids = None
+            if fork:
+                # --fork-session resumes this conversation but mints a NEW id (the
+                # original is left to its running background agent). Snapshot existing
+                # sessions so the forked one is discovered and adopted on first parse,
+                # exactly like a backend that assigns its own id.
+                self._pre_spawn_session_ids = {ref.id for ref in self.backend.list_sessions(self.repo.repo)}
+            else:
+                self._pre_spawn_session_ids = None
         else:
             session_id = self.backend.new_session_id()
             if session_id:
@@ -1187,6 +1220,7 @@ class ProxyRunner:
             self.repo.repo,
             session_id=session_id,
             resume=resume,
+            fork=fork,
             commit_guidance=self._commit_guidance,
             use_worktrees=self._use_worktrees,
             executable=self._launch_command() or None,
@@ -5515,10 +5549,27 @@ class ProxyRunner:
         # aGiTrack should stay up and relaunch+resume the conversation rather than
         # quitting with it. Guard against a crash loop: if the backend keeps dying
         # quickly, stop relaunching and exit normally.
+        # Root-cause case: the backend refused to resume because the session is held
+        # by a running background agent. Fork a copy (claude's own remedy) once,
+        # instead of relaunching into the same refusal until the crash-loop guard
+        # gives up. The forked id is discovered and adopted on the first parse (#114).
+        if self._should_fork_after_busy_exit():
+            self._forked_for_busy = True
+            self._fork_next_spawn = True
+            self.child_pid = None  # already gone
+            try:
+                self._restart_agent("Previous session is busy; forked a copy to continue.")
+            except Exception as error:
+                self._debug(f"fork relaunch failed, exiting: {error!r}")
+                self._backend_exit_notice = self._format_backend_exit_notice()
+                self._finalize_on_backend_exit()
+                return False
+            return True
         now = time.monotonic()
         recent = [t for t in self._relaunch_times if now - t < 12.0]
         if len(recent) >= 3:
             self._debug("backend exited 3x within 12s; quitting instead of relaunching")
+            self._backend_exit_notice = self._format_backend_exit_notice()
             self._finalize_on_backend_exit()
             return False
         recent.append(now)
@@ -5534,6 +5585,40 @@ class ProxyRunner:
             self._finalize_on_backend_exit()
             return False
         return True
+
+    def _should_fork_after_busy_exit(self) -> bool:
+        # True when the just-exited backend was claude refusing to resume a session
+        # that is still running as a background agent, and we have not already forked
+        # for this. Keyed off claude's own message so it tracks the CLI's behaviour
+        # rather than guessing. State-guarded so it is inert in tests without state.
+        if self._forked_for_busy:
+            return False
+        if getattr(self.state, "backend", None) != "claude":
+            return False
+        if not getattr(self.state, "backend_session_id", None):
+            return False
+        text = _strip_ansi(self.last_child_output_sample.decode(errors="replace"))
+        return bool(_FORK_HINT_RE.search(text))
+
+    def _format_backend_exit_notice(self) -> str | None:
+        # The backend died on launch several times in a row (e.g. the claude CLI
+        # refusing to resume a session that is still running as a background agent),
+        # so aGiTrack is giving up. In proxy mode that output lived on the alt-screen,
+        # which the terminal restore discards, so the user otherwise just sees a flash
+        # and a bare prompt with no reason (#114). Echo the backend's last readable
+        # lines, plus how to get unstuck.
+        backend = getattr(self.state, "backend", None) or "the backend"
+        text = _strip_ansi(self.last_child_output_sample.decode(errors="replace"))
+        lines = [line.rstrip() for line in text.splitlines() if line.strip()]
+        notice = f"aGiTrack: {backend} exited repeatedly on launch and was not relaunched."
+        if lines:
+            tail = "\n".join("  " + line for line in lines[-12:])
+            notice += f"\nLast output from {backend}:\n{tail}"
+        notice += (
+            "\nTry `agitrack --new-session` to start a fresh conversation, "
+            "or `agitrack --mode json` to see the full backend error."
+        )
+        return notice
 
     def _finalize_on_backend_exit(self) -> None:
         # The only session's backend process is gone and we are NOT relaunching

--- a/tests/test_proxy.py
+++ b/tests/test_proxy.py
@@ -6079,6 +6079,74 @@ def test_relaunch_backend_resumes_then_gives_up_on_crash_loop(monkeypatch):
     assert calls == ["relaunch", "relaunch", "relaunch", "finalize"]
 
 
+def test_crash_loop_capture_surfaces_backend_output(monkeypatch):
+    # When the backend keeps dying on launch, the crash-loop bail must capture the
+    # backend's last output so run() can echo it instead of exiting silently (#114).
+    runner = make_runner()
+    runner._debug = lambda *a, **k: None
+    runner._restart_agent = lambda msg: None
+    runner._finalize_on_backend_exit = lambda: None
+    runner.last_child_output_sample = (
+        b"\x1b[2J\x1b[HError: Session abc123 is currently running as a "
+        b"background agent (bg). Use `claude agents` ... or add --fork-session.\r\n"
+    )
+
+    t = [1000.0]
+    monkeypatch.setattr("agitrack.proxy.runner.time.monotonic", lambda: t[0])
+    for _ in range(3):
+        assert runner._relaunch_backend_or_exit() is True
+    assert runner._relaunch_backend_or_exit() is False
+
+    notice = runner._backend_exit_notice
+    assert notice is not None
+    assert "exited repeatedly" in notice
+    assert "running as a background agent" in notice  # the real reason, escapes stripped
+    assert "\x1b" not in notice
+    assert "--new-session" in notice
+
+
+def test_busy_session_forks_instead_of_crash_looping():
+    # The claude session is held by a running background agent. aGiTrack should fork a
+    # copy on the next spawn rather than relaunch into the same refusal (#114).
+    import types
+
+    runner = make_runner(
+        state=types.SimpleNamespace(backend="claude", backend_session_id="old-id"),
+        last_child_output_sample=(
+            b"Error: Session old-id is currently running as a background agent (bg). "
+            b"Use `claude agents` ... or add --fork-session to branch off a copy.\r\n"
+        ),
+    )
+    runner._debug = lambda *a, **k: None
+    messages = []
+    runner._restart_agent = lambda msg: messages.append(msg)
+
+    # First death: fork once.
+    assert runner._relaunch_backend_or_exit() is True
+    assert runner._fork_next_spawn is True
+    assert runner._forked_for_busy is True
+    assert messages and "forked" in messages[0].lower()
+
+    # If the fork ALSO dies, don't fork again — fall through to the normal guard.
+    runner._restart_agent = lambda msg: messages.append("relaunch")
+    runner._finalize_on_backend_exit = lambda: messages.append("finalize")
+    runner._relaunch_backend_or_exit()
+    assert runner._forked_for_busy is True  # not re-forked
+
+
+def test_claude_spawn_command_fork_appends_flag():
+    from pathlib import Path
+
+    from agitrack.backends.proxy_agents import ClaudeProxyAgent
+
+    agent = ClaudeProxyAgent()
+    cmd = agent.spawn_command(Path("/repo"), session_id="abc", resume=True, fork=True, commit_guidance=False)
+    assert cmd[:4] == ["claude", "--resume", "abc", "--fork-session"]
+    # No fork flag when not forking.
+    cmd_plain = agent.spawn_command(Path("/repo"), session_id="abc", resume=True, fork=False, commit_guidance=False)
+    assert "--fork-session" not in cmd_plain
+
+
 def test_relaunch_backend_resets_loop_guard_after_quiet_period(monkeypatch):
     runner = make_runner()
     runner._debug = lambda *a, **k: None
@@ -6923,7 +6991,7 @@ def test_spawn_failed_exec_child_exits_with_127(tmp_path):
         worktree=None,
         backend=types.SimpleNamespace(
             new_session_id=lambda: "ses-1",
-            spawn_command=lambda repo, session_id, resume, commit_guidance=True, use_worktrees=True, executable=None: [
+            spawn_command=lambda repo, session_id, resume, fork=False, commit_guidance=True, use_worktrees=True, executable=None: [
                 "agit-test-binary-that-does-not-exist"
             ],
             list_sessions=lambda repo: [],


### PR DESCRIPTION
Fixes #114.

## Problem
aGiTrack resumes the last `claude` session by default. When that session is still held by a running background agent, the `claude` CLI refuses to attach and exits:

```
Error: Session <id> is currently running as a background agent (bg). Use `claude agents`
to find and attach to it, or add --fork-session to branch off a copy.
```

In proxy mode the backend's error is rendered onto the alt-screen, which the terminal restore discards on exit. The runner relaunches into the same refusal until the crash-loop guard gives up, so the user sees only a brief flash and a bare prompt, with no reason. (`--mode json` already prints the error; only proxy mode hides it.)

## Fix
**Fork instead of failing.** When a resumed `claude` session dies on launch with that signal, aGiTrack re-spawns once with `--fork-session` (claude's own documented remedy). This branches off a copy of the conversation, leaves the busy agent untouched, and the forked session's new id is adopted through the existing post-spawn discovery path (`_discover_spawned_session`, the same mechanism used for backends that assign their own id). Guarded to fork only once, so a fork that also dies falls through to the normal crash-loop handling.

As a safety net for cases forking does not cover (other backends, other launch failures), the runner now surfaces the backend's last output on the restored host screen when it gives up, instead of exiting with just a flash.

## Verification
Confirmed against the live `claude` CLI on a busy session:

- `claude --resume <busy>` → reproduces the error above.
- `claude --resume <busy> --fork-session` → `is_error=false`, succeeds with a fresh session id.

## Changes
- `backends/proxy_agents.py`: `spawn_command` gains a `fork` parameter; the claude backend appends `--fork-session`, opencode accepts and ignores it (no fork concept).
- `proxy/runner.py`: `_should_fork_after_busy_exit` detection (keyed off claude's message, fork-once guard), the fork branch in `_spawn` (snapshots existing sessions so the fork is discovered), the fork hook in `_relaunch_backend_or_exit`, and the `_backend_exit_notice` safety net printed after teardown.
- `tests/test_proxy.py`: tests for the fork decision, the fork-once guard, the claude `spawn_command` flag, and the exit-notice capture.

Full suite: `1394 passed, 1 skipped`.