### PR TITLE
Further improve webpage

### DIFF
--- a/docs/docs.html
+++ b/docs/docs.html
@@ -3,7 +3,7 @@
 <head>
 <meta charset="utf-8">
 <meta name="viewport" content="width=device-width, initial-scale=1">
-<title>aGiTrack Documentation — the full manual & user-flow diagrams</title>
+<title>aGiTrack Documentation: the full manual & user-flow diagrams</title>
 <meta name="description" content="aGiTrack documentation: the full manual and the interactive user-flow diagrams, rendered live from the project's own README and user-flow files.">
 <link rel="canonical" href="https://agitrack.core-aix.org/docs.html">
 <meta name="robots" content="index, follow, max-image-preview:large, max-snippet:-1">
@@ -214,11 +214,11 @@ summary.toc-title::after{content:""} /* caret only shown on mobile (see media qu
   <aside class="toc" id="toc" aria-label="Table of contents"></aside>
   <div>
     <section class="doc on" id="doc-manual">
-      <p class="srcnote">Rendered live from <a href="https://github.com/core-aix/agitrack/blob/main/README.md">README.md</a> — the project's canonical manual.</p>
+      <p class="srcnote">Rendered live from <a href="https://github.com/core-aix/agitrack/blob/main/README.md">README.md</a>, the project's canonical manual.</p>
       <div class="md" id="md-manual"><p class="status">Loading the manual…</p></div>
     </section>
     <section class="doc" id="doc-userflow">
-      <p class="srcnote">Rendered live from <a href="https://github.com/core-aix/agitrack/blob/main/docs/user-flow.md">docs/user-flow.md</a> — the source of truth for aGiTrack's interactive flow.</p>
+      <p class="srcnote">Rendered live from <a href="https://github.com/core-aix/agitrack/blob/main/docs/user-flow.md">docs/user-flow.md</a>, the source of truth for aGiTrack's interactive flow.</p>
       <div class="md" id="md-userflow"><p class="status">Loading the user flow…</p></div>
     </section>
   </div>

--- a/docs/index.html
+++ b/docs/index.html
@@ -3,8 +3,8 @@
 <head>
 <meta charset="utf-8">
 <meta name="viewport" content="width=device-width, initial-scale=1">
-<title>aGiTrack — every AI coding-agent turn becomes a traceable Git commit</title>
-<meta name="description" content="aGiTrack wraps your coding agent backends with Git: every agent turn becomes a traceable commit carrying the full interaction trace, model, and token cost — with a live dashboard of what your agents did.">
+<title>aGiTrack: every AI coding-agent turn becomes a traceable Git commit</title>
+<meta name="description" content="aGiTrack wraps your coding agent backends with Git: every agent turn becomes a traceable commit carrying the full interaction trace, model, and token cost, plus a live dashboard of what your agents did.">
 <link rel="canonical" href="https://agitrack.core-aix.org/">
 <meta name="robots" content="index, follow, max-image-preview:large, max-snippet:-1">
 <meta name="author" content="core-aix">
@@ -16,14 +16,14 @@
 <!-- Open Graph / social preview -->
 <meta property="og:type" content="website">
 <meta property="og:site_name" content="aGiTrack">
-<meta property="og:title" content="aGiTrack — every AI coding-agent turn, committed with its story">
-<meta property="og:description" content="Wrap your coding agent backends with Git: every agent turn becomes a traceable commit carrying the full interaction trace, model, and token cost — with a live dashboard of what your agents did.">
+<meta property="og:title" content="aGiTrack: every AI coding-agent turn, committed with its story">
+<meta property="og:description" content="Wrap your coding agent backends with Git: every agent turn becomes a traceable commit carrying the full interaction trace, model, and token cost, plus a live dashboard of what your agents did.">
 <meta property="og:url" content="https://agitrack.core-aix.org/">
 <meta property="og:image" content="https://agitrack.core-aix.org/images/dashboard-v4.png">
 <meta property="og:image:alt" content="The aGiTrack dashboard: agent commits, token usage, and efficiency insights.">
 <meta property="og:locale" content="en_US">
 <meta name="twitter:card" content="summary_large_image">
-<meta name="twitter:title" content="aGiTrack — every AI coding-agent turn, committed with its story">
+<meta name="twitter:title" content="aGiTrack: every AI coding-agent turn, committed with its story">
 <meta name="twitter:description" content="Wrap your coding agent backends with Git: every agent turn becomes a traceable commit with the full interaction trace, model, and token cost.">
 <meta name="twitter:image" content="https://agitrack.core-aix.org/images/dashboard-v4.png">
 <!-- Structured data: helps Google understand the project and show a last-updated date -->
@@ -204,6 +204,10 @@ pre{font-family:var(--mono);white-space:pre;line-height:1.55}
   padding:9px 13px;font-size:13.5px;color:var(--phosphor);
 }
 .step .note{font-size:12.5px;color:var(--fg-dim);margin-top:5px}
+.backends-list{list-style:none;margin:4px 0 12px;display:flex;flex-direction:column;gap:8px}
+.backends-list li{color:var(--fg);font-size:14.5px}
+.backends-list strong{color:var(--phosphor);font-weight:600}
+.backends-list .cmd{color:var(--fg-dim);font-size:13px}
 
 footer{
   padding:34px 0 60px;color:var(--fg-dim);font-size:13px;
@@ -356,15 +360,15 @@ Added --version using the package metadata; prints and exits.
         <span class="subject"><span class="tag">&lt;aGiTrack&gt;</span> surface how the agents are being driven</span>
       </div>
       <h2>Not how much it wrote. How well you drove it.</h2>
-      <p>The dashboard mines your history for the habits that quietly cost you time and tokens &mdash; correction
-      loops, rework hotspots, unverified turns, ballooning context &mdash; and tells you what to change, each finding
+      <p>The dashboard mines your history for the habits that quietly cost you time and tokens: correction
+      loops, rework hotspots, unverified turns, ballooning context. Then it tells you what to change, each finding
       backed by the numbers behind it.</p>
       <p>It follows the <strong>filter</strong>, so narrowing to last week scores last week, and every card shows
       whether the habit is <span class="p">&darr;</span> improving or <span class="p">&uarr;</span> getting worse.</p>
       <div class="term">
         <div class="term-bar"><span class="dot r"></span><span class="dot y"></span><span class="dot g"></span><span class="title">agitrack -d · agent efficiency</span></div>
         <a href="images/efficiency-insights.png" target="_blank"><img class="shot" src="images/efficiency-insights.png" loading="lazy"
-          alt="The agent efficiency panel: a HIGH 'Rework hotspots' card, a MEDIUM 'Correction loops' card trending 66% worse than earlier, and a green 'Fragmented sessions: improved' card 71% better — each with the numbers behind it and a suggested change."></a>
+          alt="The agent efficiency panel: a HIGH 'Rework hotspots' card, a MEDIUM 'Correction loops' card trending 66% worse than earlier, and a green 'Fragmented sessions: improved' card 71% better, each with the numbers behind it and a suggested change."></a>
       </div>
     </section>
 
@@ -395,6 +399,20 @@ Added --version using the package metadata; prints and exits.
       </div>
     </section>
 
+    <section class="commit" id="backends">
+      <div class="commit-head">
+        <span class="sha">b4ck3nd</span>
+        <span class="subject">supported backends</span>
+      </div>
+      <h2>Bring your own coding agent.</h2>
+      <p>aGiTrack wraps the coding agent you already use. Supported today:</p>
+      <ul class="backends-list">
+        <li><span class="o">▸</span> <strong>Claude Code</strong> <span class="cmd">agitrack --backend claude</span></li>
+        <li><span class="o">▸</span> <strong>OpenCode</strong> <span class="cmd">agitrack --backend opencode</span></li>
+      </ul>
+      <p>More backends are planned. <a href="https://github.com/core-aix/agitrack/issues">Request one.</a></p>
+    </section>
+
     <section class="commit" id="install">
       <div class="commit-head">
         <span class="sha">e8d2fa0</span>
@@ -418,31 +436,6 @@ Added --version using the package metadata; prints and exits.
       <p style="margin-top:18px">Prompt the agent as usual. When the turn settles, the commit is already there.
       <span class="p">git log</span> tells the rest. Prefer an editor? aGiTrack also runs as a
       <a href="docs.html#vs-code-extension">VS Code extension</a>, one click, same experience.</p>
-    </section>
-
-    <section class="commit" id="backends">
-      <div class="commit-head">
-        <span class="sha">b4ck3nd</span>
-        <span class="subject">supported backends</span>
-      </div>
-      <h2>Bring your own coding agent.</h2>
-      <p>aGiTrack is backend-agnostic: it wraps the coding agent you already use and records its work the same
-      way, whichever one it is. Two are supported today, and the list is designed to grow.</p>
-      <div class="branches two">
-        <div class="branch" data-ref="agitrack --backend claude">
-          <h3>Claude Code</h3>
-          <p>Anthropic's coding agent CLI. Full support: interactive TUI, background/headless tracking, per-turn
-          commits with the complete interaction trace, model, and token cost.</p>
-        </div>
-        <div class="branch" data-ref="agitrack --backend opencode">
-          <h3>OpenCode</h3>
-          <p>The open-source coding agent, run against any provider/model it supports. Same per-turn tracking,
-          dashboard, and traced commits as every other backend.</p>
-        </div>
-      </div>
-      <p style="margin-top:16px"><strong>More backends are on the roadmap.</strong> aGiTrack talks to each agent
-      through a small backend adapter, so support for additional coding agents can be added without changing how
-      your commits, dashboard, or history work. Want one covered? <a href="https://github.com/core-aix/agitrack/issues">Open an issue.</a></p>
     </section>
 
     <section class="commit agent">


### PR DESCRIPTION
The "Supported backends" section was restructured to appear before installation instructions with a simplified two-item list and minimal prose. Simultaneously, all visible em-dashes were eliminated from rendered HTML content. In index.html, 9 em-dashes across titles, descriptions, and body copy were replaced with contextually appropriate punctuation: colons for title clarity, commas for list separation, and periods for sentence breaks. In docs.html, 3 rendered em-dashes in captions and the page title were similarly converted. Fourteen em-dashes
 remain in CSS and JavaScript code comments within the source, but these
 are invisible to page visitors and were intentionally left to avoid
unnecessary churn. The change preserves all semantic meaning while maintaining a cleaner, more accessible typographic presentation across both pages.

# Interaction Trace

## User

The supported backends section is too long. Make it much shorter just to
 include a simple list. Also the list should appear before the
installation instructinos

## Agent

Done. The "Supported backends" section is now:

- **Much shorter** — a heading, one intro line, a simple two-item list (Claude Code / OpenCode, each with its `--backend` command in dim text),
 and a one-line "More backends are planned — request one." No per-
backend paragraphs or cards.
- **Before the installation instructions** — the section order is now backtrace → **supported backends** → install → CTA (verified: `section order: ['backends', 'install']`).

Single `id="backends"`, all in-page anchors still resolve (the hero's "See supported backends ↓" and the install note both still point to it),
 and the JSON-LD is intact. Added a small `.backends-list` CSS rule
matching the page's terminal aesthetic (amber `▸`, green backend names, dim commands). Rendered and screenshot-verified.

## User

Also avoid using em-dashes in the webpage

## Agent

All clean and rendering correctly. Summary:

**index.html — fully em-dash-free (0 remaining, all encodings checked: literal `—`, `&mdash;`, `&#8212;`).** Replaced all 9 with context- appropriate punctuation:
- Titles / OG / Twitter titles: `aGiTrack — every…` → `aGiTrack: every…` (colon)
- Meta + OG descriptions: `…token cost — with a live dashboard` → `…token cost, plus a live dashboard`
- Efficiency prose (was `&mdash;`): `…time and tokens — correction loops … ballooning context — and tells you` → `…time and tokens: correction loops … ballooning context. Then it tells you`
- Image alt text: `71% better — each with` → `71% better, each with`
- Backends line: `More backends are planned — request one.` → `More backends are planned. Request one.`

**docs.html — the 3 visible em-dashes fixed** (page title and the two "Rendered live from …" source captions → commas/colon).

One thing I deliberately left, so you can decide: docs.html still has **14 em-dashes, but all inside CSS/JS code comments** (e.g. `/* … min- widths — a plain 1fr … */`, `// Render … — but ONLY while visible`). None are rendered on the page, so the *webpage* itself is em-dash-free. I didn't rewrite them because they're implementation notes a visitor never sees and editing them is pure churn/risk — but if you want the source clean too, say the word and I'll sweep them.

(The `--backend claude` you see in the list is the literal CLI flag `--`
 in mono font, not an em-dash.)

# aGiTrack Metadata
commit_type: agent
backend: claude
model: claude-opus-4-8
reasoning_effort: on
session_name: crab
agitrack_session_id: agitrack-ff15afec-4b0d-4822-a356-1e314c4d674c backend_session_id: 0a14713a-2774-45fe-8904-21d543db8fc4 conversation_anchor: msg_011Cd59aHk7tuCQni5kPg2V3
agent_started_at: 2026-07-16T04:55:04Z
agent_ended_at: 2026-07-16T05:01:34Z
context_tokens: 503666
tokens_since_last_commit_input: 28903
tokens_since_last_commit_cache_read: 16123444
tokens_since_last_commit_cache_write: 28841
tokens_since_last_commit_output: 18000
system: macOS 15.7.3
summary_model: claude-haiku-4-5-20251001
summary_tokens_input: 3019
summary_tokens_output: 696
agitrack_version: 0.4.2