### PR TITLE
Further improve webpage

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -14,6 +14,10 @@ aGiTrack stands for agent + git tracking. It is a Python library and interactive
 
 - `docs/user-flow.md` holds the complete, graph-rendered map of aGiTrack's interactive user flow (Mermaid flowcharts: startup gating, base↔worktree commit/stage/sync, the agent turn and integration, copy-back, the Ctrl-G menu, self-update, exit). It is linked prominently from the README. **It must be kept in sync with the actual flow:** whenever the user flow changes — a new or reworded prompt, a changed option label, a new decision based on file/commit/session status, a new Ctrl-G command, or a changed exit/update path — update the matching diagram in the same change.
 
+## Writing Style
+
+- **Do not use em-dashes** (Unicode U+2014, or the `&mdash;` / `&#8212;` HTML entities) in prose aGiTrack produces or ships: the website (`docs/index.html`, `docs/docs.html`), the README, docs, and other user-facing text. Use a colon, comma, parentheses, or a period instead.
+
 ## Commit Types
 
 - Agent commits use the `<aGiTrack>` tag.

--- a/docs/index.html
+++ b/docs/index.html
@@ -230,7 +230,7 @@ footer .sha{font-size:12px}
     <p class="tagline reveal r2"><span class="tag">&lt;aGiTrack&gt;</span> every agent turn, committed with its story<span class="cursor"></span></p>
     <p class="sub reveal r3">aGiTrack runs your <strong>coding agent backend</strong> for you and turns every finished
     agent turn into a git commit, recording what you asked, what it did, the model, and the tokens it cost. Use
-    the agent exactly as you would on its own. <a href="#backends">See supported backends ↓</a></p>
+    the agent exactly as you would on its own.</p>
     <div class="hero-actions reveal r4">
       <a class="btn" href="#install">pip install agitrack</a>
       <a class="btn alt" href="docs.html">read the docs</a>
@@ -360,11 +360,9 @@ Added --version using the package metadata; prints and exits.
         <span class="subject"><span class="tag">&lt;aGiTrack&gt;</span> surface how the agents are being driven</span>
       </div>
       <h2>Not how much it wrote. How well you drove it.</h2>
-      <p>The dashboard mines your history for the habits that quietly cost you time and tokens: correction
-      loops, rework hotspots, unverified turns, ballooning context. Then it tells you what to change, each finding
-      backed by the numbers behind it.</p>
-      <p>It follows the <strong>filter</strong>, so narrowing to last week scores last week, and every card shows
-      whether the habit is <span class="p">&darr;</span> improving or <span class="p">&uarr;</span> getting worse.</p>
+      <p>The dashboard surfaces the habits that quietly cost time and tokens: correction loops, rework hotspots,
+      unverified turns, ballooning context. It scores the current filter and flags each one
+      <span class="p">&darr;</span> improving or <span class="p">&uarr;</span> getting worse, backed by the numbers.</p>
       <div class="term">
         <div class="term-bar"><span class="dot r"></span><span class="dot y"></span><span class="dot g"></span><span class="title">agitrack -d · agent efficiency</span></div>
         <a href="images/efficiency-insights.png" target="_blank"><img class="shot" src="images/efficiency-insights.png" loading="lazy"
@@ -378,15 +376,10 @@ Added --version using the package metadata; prints and exits.
         <span class="subject"><span class="tag">&lt;aGiTrack&gt;</span> reconstruct history from past sessions</span>
       </div>
       <h2>Didn't use it from day one? Show the history anyway.</h2>
-      <p>Already built your project with a coding agent, without aGiTrack? Run
-      <span class="p">agitrack --backtrace</span>. It reads the coding-agent transcripts already on your machine and
-      <strong>reconstructs</strong> what those sessions did here: tokens, models, lines changed, the file-by-file history,
-      and the full conversation behind every change, in the same dashboard, clearly marked as a historical
-      view. No prior aGiTrack use, nothing uploaded, and it works even in a folder that was never a git repo.</p>
-      <p>Want it in your <strong>real</strong> git history? <span class="p">agitrack --backtrace commit</span>
-      replays your commits onto a new branch and stamps the aGiTrack metadata onto the ones your agents produced,
-      keeping your own commits verbatim. It only ever writes to a new branch and leaves your current one untouched;
-      just run it and follow the prompts.</p>
+      <p>Built your project with a coding agent before aGiTrack? <span class="p">agitrack --backtrace</span>
+      <strong>reconstructs</strong> what those past sessions did from the transcripts already on your machine:
+      tokens, models, lines changed, and the conversation behind every change, in the same dashboard. Nothing
+      uploaded, and it works even outside a git repo.</p>
       <div class="steps" style="margin-top:22px">
         <div class="step"><div>
           <code>agitrack --backtrace</code>


### PR DESCRIPTION
The webpage (`docs/index.html`) was trimmed in three places: the "See supported backends ↓" link was removed from the hero section, the efficiency section was condensed from two paragraphs into a single tight
 sentence explaining how the dashboard surfaces costly habits and scores
 filters, and the backtrace section was shortened by dropping redundant
explanation that duplicates the numbered steps below. All changes maintain zero em-dashes in the HTML while preserving the `#backends` anchor for internal navigation.

A new **Writing Style** section was added to the project memory file (`AGENTS.md`) establishing a rule against em-dashes (Unicode U+2014, `&mdash;`, or `&#8212;`) in any prose aGiTrack produces or ships. The rule itself is written without em-dashes by naming the character by codepoint, ensuring the policy is self-consistent.

One limitation: the efficiency screenshot (`efficiency-insights.png`) still contains em-dashes because they're embedded in the PNG from aGiTrack's generated suggestion text in `insights.py`. Removing those would require modifying the suggestion strings and regenerating the image as a separate change.

# Interaction Trace

## User

Remove the "See supported backends ↓" at the top of the webpage. Also shorten the text in the "Not how much it wrote. How well you drove it." and "Didn't use it from day one? Show the history anyway." sections

## User

Add no em-dash to your memory file that is committed into git

## Agent

All three webpage changes are in and rendering cleanly, plus the memory rule. Summary:

**Webpage (`docs/index.html`):**
1. **Removed** the "See supported backends ↓" link from the hero — it now ends at "Use the agent exactly as you would on its own."
2. **Shortened the efficiency section** ("Not how much it wrote…") — the two paragraphs are now one tight sentence: *"The dashboard surfaces the habits that quietly cost time and tokens: correction loops, rework hotspots, unverified turns, ballooning context. It scores the current filter and flags each one ↓ improving or ↑ getting worse, backed by the numbers."*
3. **Shortened the backtrace section** ("Didn't use it from day one?…") — dropped the second paragraph (the `--backtrace commit` details are already in the numbered steps below) and trimmed the first to one sentence.

Still 0 em-dashes, and the install note's `#backends` anchor still resolves (only the hero link was removed).

**Committed memory (`AGENTS.md`):** Added a **Writing Style** section with the rule: *"Do not use em-dashes (Unicode U+2014, or the `&mdash;` / `&#8212;` HTML entities) in prose aGiTrack produces or ships…"*. I named the character by codepoint rather than embedding it, so the rule itself contains zero em-dashes.

One caveat to flag: the efficiency **screenshot image** (`efficiency- insights.png`) still shows em-dashes inside it — those come from aGiTrack's own generated suggestion text (`insights.py`), baked into the
 PNG, not from the page HTML. If you want those gone too, that's a
separate change (drop em-dashes from the suggestion strings in `insights.py`, then regenerate the screenshot). Say the word and I'll do
 it.

# aGiTrack Metadata
commit_type: agent
backend: claude
model: claude-opus-4-8
reasoning_effort: on
session_name: crab
agitrack_session_id: agitrack-ff15afec-4b0d-4822-a356-1e314c4d674c backend_session_id: 0a14713a-2774-45fe-8904-21d543db8fc4 conversation_anchor: msg_011Cd5DwiLGWg9dYZLx3d7dP
agent_started_at: 2026-07-16T05:55:02Z
agent_ended_at: 2026-07-16T05:59:00Z
context_tokens: 524146
tokens_since_last_commit_input: 19513
tokens_since_last_commit_cache_read: 10250501
tokens_since_last_commit_cache_write: 19476
tokens_since_last_commit_output: 12276
system: macOS 15.7.3
summary_model: claude-haiku-4-5-20251001
summary_tokens_input: 2842
summary_tokens_output: 614
agitrack_version: 0.4.2