### PR TITLE
<aGiTrack> Fixed release pipeline resilience, mobile layout, scroll behavior

### DIFF
--- a/.github/workflows/release-patch.yml
+++ b/.github/workflows/release-patch.yml
@@ -138,7 +138,23 @@ jobs:
       - name: Publish to PyPI
         env:
           UV_PUBLISH_TOKEN: ${{ secrets.PYPI_TOKEN }}
-        run: uv publish
+        # By this point the version bump has ALREADY merged to main, so a transient
+        # upload failure here leaves a half-finished release (main claims a version that
+        # was never published). Retry with backoff, and pass --check-url so an upload
+        # that actually landed before the client gave up is skipped on the retry instead
+        # of failing it as a duplicate file. If every attempt fails, recover by pushing
+        # the tag: release-tag.yml checks out main, finds the version files already in
+        # sync, and completes the publish/release/extension/MSI steps.
+        run: |
+          for attempt in 1 2 3 4 5; do
+            if uv publish --check-url https://pypi.org/simple/agitrack/; then
+              exit 0
+            fi
+            echo "publish attempt ${attempt} failed; retrying in $((attempt * 20))s..."
+            sleep $((attempt * 20))
+          done
+          echo "::error::could not publish to PyPI after 5 attempts"
+          exit 1
 
       # Summarize the key changes since the previous release with the OpenAI API
       # (shared composite action). AI-only: this step FAILS the release with a

--- a/.github/workflows/release-tag.yml
+++ b/.github/workflows/release-tag.yml
@@ -116,7 +116,23 @@ jobs:
       - name: Publish to PyPI
         env:
           UV_PUBLISH_TOKEN: ${{ secrets.PYPI_TOKEN }}
-        run: uv publish
+        # By this point the version bump has ALREADY merged to main, so a transient
+        # upload failure here leaves a half-finished release (main claims a version that
+        # was never published). Retry with backoff, and pass --check-url so an upload
+        # that actually landed before the client gave up is skipped on the retry instead
+        # of failing it as a duplicate file. If every attempt fails, recover by pushing
+        # the tag: release-tag.yml checks out main, finds the version files already in
+        # sync, and completes the publish/release/extension/MSI steps.
+        run: |
+          for attempt in 1 2 3 4 5; do
+            if uv publish --check-url https://pypi.org/simple/agitrack/; then
+              exit 0
+            fi
+            echo "publish attempt ${attempt} failed; retrying in $((attempt * 20))s..."
+            sleep $((attempt * 20))
+          done
+          echo "::error::could not publish to PyPI after 5 attempts"
+          exit 1
 
       # Summarize the key changes since the previous release with the OpenAI API
       # (shared composite action). The change range ends at this tag. AI-only:

--- a/agitrack/metrics/export.py
+++ b/agitrack/metrics/export.py
@@ -294,20 +294,41 @@ def _shim(*, base: str, files_index: dict[str, int], learn: bool, site_root: str
         }});
         if (target) {{
           clearInterval(tick);
+          // Only chrome that is ACTUALLY pinned to the top can cover the entry. The filter
+          // bar is sticky on a desktop but scrolls away on a phone, where reserving its
+          // (tall, wrapped) height parked the entry a screenful too low — with earlier
+          // commits filling the gap. So measure the stuck elements' bottom edge rather
+          // than blindly summing heights.
+          var inset = function(){{
+            var bottom = 0;
+            [".backtracebanner", ".controls"].forEach(function(sel){{
+              var el = document.querySelector(sel);
+              if (!el) return;
+              var pos = getComputedStyle(el).position;
+              if (pos !== "sticky" && pos !== "fixed") return;
+              bottom = Math.max(bottom, el.getBoundingClientRect().bottom);
+            }});
+            return bottom + 10;
+          }};
           // Two scrolls, not one: the commit message lives in its own scrollable box
           // (.dmsg, max-height-capped), so the WINDOW pins the expanded ENTRY right
           // below the sticky chrome (the commit fills the view, no earlier entries
           // showing) while the BOX scrolls internally so the trace starts at its top.
           var box = target.closest ? target.closest(".dmsg") : null;
+          // The page scrolls smoothly by default (html{{scroll-behavior:smooth}}), which
+          // makes every correction animate — each next one then measures a position
+          // mid-flight and overshoots, so the view visibly ran down past the commit and
+          // crept back up. Corrections must be instant; restore the page default after.
+          var root = document.documentElement, priorBehavior = root.style.scrollBehavior;
+          root.style.scrollBehavior = "auto";
+          var done = function(){{ clearInterval(pin); root.style.scrollBehavior = priorBehavior; }};
           var settled = 0, corrections = 0;
           var pin = setInterval(function(){{
-            var strip = document.querySelector(".backtracebanner"), bar = document.querySelector(".controls");
-            var want = (strip ? strip.offsetHeight : 0) + (bar ? bar.offsetHeight : 0) + 10;
             if (box) box.scrollTop += Math.round(target.getBoundingClientRect().top - box.getBoundingClientRect().top);
-            var drift = entry.getBoundingClientRect().top - want;
-            if (Math.abs(drift) <= 2) {{ if (++settled >= 4) clearInterval(pin); return; }}
+            var drift = entry.getBoundingClientRect().top - inset();
+            if (Math.abs(drift) <= 2) {{ if (++settled >= 4) done(); return; }}
             settled = 0;
-            if (++corrections > 50) {{ clearInterval(pin); return; }}
+            if (++corrections > 60) {{ done(); return; }}
             window.scrollBy(0, drift);
           }}, 100);
         }}

--- a/agitrack/metrics/learn.py
+++ b/agitrack/metrics/learn.py
@@ -1626,26 +1626,34 @@ textarea{width:100%;min-height:74px;resize:vertical}
 .bubble.typing .tdot:nth-child(2){animation-delay:.2s}
 .bubble.typing .tdot:nth-child(3){animation-delay:.4s}
 @keyframes tblink{0%,60%,100%{opacity:.25;transform:translateY(0)}30%{opacity:1;transform:translateY(-3px)}}
-.progress .pstats{display:flex;gap:22px;flex-wrap:wrap;margin-bottom:10px}
+/* Positioned so the stat tooltips below anchor to the ROW, not to an individual stat:
+   a fixed-width bubble hanging off the last stat stuck out past the viewport and gave the
+   whole page a horizontal scrollbar on a phone, even while invisible, since an absolutely
+   positioned box still contributes scrollable overflow. */
+.progress .pstats{display:flex;gap:22px;flex-wrap:wrap;margin-bottom:10px;position:relative}
 /* Stat tooltips are drawn by CSS (::after on hover): reliable and instant, unlike the
    native title bubble, which proved flaky over these elements. */
-.pstat{cursor:help;position:relative}
+.pstat{cursor:help}
 .pstat b{color:var(--phosphor);font-size:17px}
 .pstat span{color:var(--fg-dim);font-size:12px;display:block;border-bottom:1px dotted var(--line)}
 .pstat::after{content:attr(data-tip);position:absolute;left:0;top:100%;margin-top:8px;z-index:20;
-  width:240px;background:var(--panel2);border:1px solid var(--phosphor-dim);border-radius:6px;
+  width:min(240px,100%);background:var(--panel2);border:1px solid var(--phosphor-dim);border-radius:6px;
   padding:8px 11px;font-size:11.5px;color:var(--fg);line-height:1.5;
   opacity:0;visibility:hidden;pointer-events:none;transition:opacity .15s;
   box-shadow:0 8px 24px rgba(0,0,0,.45)}
 .pstat:hover::after{opacity:1;visibility:visible}
 .ppager{display:flex;align-items:center;justify-content:center;gap:14px;padding:10px 0 2px;
   border-top:1px solid var(--line)}
-.plist .pl{display:flex;align-items:baseline;gap:10px;padding:7px 4px;border-top:1px solid var(--line);
-  font-size:13px;cursor:pointer}
+/* The row WRAPS and its title SHRINKS (min-width:0, since a flex item will not go below
+   its content width otherwise): a long lesson title next to non-shrinking badges pushed
+   the row past the viewport, which put a horizontal scrollbar on the whole page. */
+.plist .pl{display:flex;flex-wrap:wrap;align-items:baseline;gap:10px;padding:7px 4px;
+  border-top:1px solid var(--line);font-size:13px;cursor:pointer}
 .plist .pl:hover .plt{color:var(--accent)}
 .plist .st{flex:none;width:16px}
-.plist .plt{flex:1}
-.plist .pmeta{color:var(--fg-dim);font-size:11.5px;flex:none;display:flex;gap:6px;align-items:baseline}
+.plist .plt{flex:1 1 55%;min-width:0;overflow-wrap:anywhere}
+.plist .pmeta{color:var(--fg-dim);font-size:11.5px;flex:none;display:flex;flex-wrap:wrap;gap:6px;
+  align-items:baseline;max-width:100%}
 .plist .pldel{flex:none;background:none;border:none;color:var(--fg-dim);font:inherit;font-size:12px;
   cursor:pointer;padding:2px 6px;border-radius:4px;opacity:0;visibility:hidden;transition:color .15s}
 .plist .pl:hover .pldel,.plist .pldel:focus-visible{opacity:1;visibility:visible}

--- a/agitrack/metrics/web.py
+++ b/agitrack/metrics/web.py
@@ -161,7 +161,7 @@ def _update_banner_html(repo: GitRepo) -> str:
         info = None
     if not info:
         return ""
-    text = f"aGiTrack update available: {info.get('current', '?')} → {info.get('latest', '?')} — run `agitrack` and choose ‘update’, or update via pip/pipx/brew."
+    text = f"aGiTrack update available: {info.get('current', '?')} → {info.get('latest', '?')} — run `agitrack` and choose ‘update’, or update via pip/pipx."
     return f'<div class="updatebanner">⬆ {_escape(text)}</div>'
 
 

--- a/agitrack/update/marker.py
+++ b/agitrack/update/marker.py
@@ -62,4 +62,6 @@ def update_reminder_line(repo_root: Path) -> str | None:
     if not info:
         return None
     current, latest = info.get("current", "?"), info.get("latest", "?")
-    return f"aGiTrack update available: {current} → {latest} (run `agitrack` and choose 'update', or update via pip/pipx/brew)."
+    return (
+        f"aGiTrack update available: {current} → {latest} (run `agitrack` and choose 'update', or update via pip/pipx)."
+    )

--- a/tests/FLOW_MATRIX.md
+++ b/tests/FLOW_MATRIX.md
@@ -229,6 +229,7 @@ directory that is not a git repo still gets the full page, with progress sync re
 
 | Sequence | Test(s) | Kind |
 |---|---|---|
+| The page fits a phone exactly (no horizontal scrollbar): progress rows wrap and their titles shrink, and the stat tooltip anchors to the stats ROW capped at its width — an absolutely positioned bubble adds scrollable overflow even while invisible | `test_learn_page_fits_a_phone_width_exactly` | real-git |
 | Engine resolution: config keys > latest session backend/model; cross-backend model dropped; none → clear error | `test_resolve_prefers_config_over_latest_session`, `_falls_back_to_latest_session`, `_config_model_wins`, `_without_any_backend_raises` | real-git |
 | Engine picker persists to / clears from the repo config overlay; unknown backend refused | `test_set_learning_config_roundtrip`, `_rejects_unknown_backend` | real-git |
 | Check-in → suggestions: digest covers prompts/insights/files/README/progress; capped; persisted per GitHub user; agent failure and empty window surface as in-page errors; one agent call at a time | `test_digest_*`, `test_suggest_persists_profile_per_user`, `_reports_agent_failure_as_error`, `_with_no_turns_explains_instead_of_calling_agent`, `test_agent_lock_reports_busy` | real-git |
@@ -264,6 +265,7 @@ agitrack.core-aix.org/dashboard/, rebuilt by `.github/workflows/pages.yml` on ea
 | The demo ships the last 30 days (anchored to the newest commit, never empty), not all time: log pages, embedded first paint, and baked diffs are scoped; the banner and the disabled range dropdown say "last 30 days" | `test_export_scopes_the_demo_to_the_last_30_days` | real-git |
 | The fetch shim is installed before any page script runs | `test_export_shim_installs_before_the_page_script` | real-git |
 | Honest degradation: demo banner + install hint on both pages, filter controls disabled, agent-driven learn POSTs answered with the install hint; tapping a disabled filter or the reset button flashes the same demo note as a fixed toast (learn-page style, click to dismiss) | `test_export_writes_a_complete_static_site`, `test_export_disables_filters_and_cans_learn_actions` | real-git |
+| The `#trace` deep link maximizes the expanded commit: the window parks the ENTRY under the chrome that is ACTUALLY stuck (the filter bar is sticky on desktop but scrolls away on a phone) and the message box scrolls internally to its Interaction Trace; corrections scroll instantly, so the view never overshoots and creeps back | `test_export_disables_filters_and_cans_learn_actions` | real-git |
 | Learn profile fallback: the store's single non-empty profile ships when the exporting identity has none (how CI exports the checked-in fixture) | `test_export_learn_state_falls_back_to_the_single_store_profile` | real-git |
 | CLI: `-d export --export-dir` writes the site and reports the path | `test_cli_export_writes_the_site` | real-git |
 

--- a/tests/test_export.py
+++ b/tests/test_export.py
@@ -118,7 +118,13 @@ def test_export_disables_filters_and_cans_learn_actions(tmp_path, monkeypatch):
     # scrolls internally so the Interaction Trace starts at its top.
     assert 'location.hash === "#trace"' in index
     assert "box.scrollTop +=" in index
-    assert "entry.getBoundingClientRect().top - want" in index
+    assert "entry.getBoundingClientRect().top - inset()" in index
+    # The inset counts only chrome that is ACTUALLY stuck: the filter bar is sticky on a
+    # desktop but scrolls away on a phone, where reserving its height parked the entry a
+    # screenful too low. And corrections scroll INSTANTLY — with the page's default smooth
+    # behavior each correction measured a mid-animation position and visibly overshot.
+    assert 'pos !== "sticky" && pos !== "fixed"' in index
+    assert 'root.style.scrollBehavior = "auto"' in index
     # The learn page shows the same note in the same amber notice style: its error-path
     # flashes carrying the demo note are restyled to notices (real errors stay red).
     learn = (out / "learn" / "index.html").read_text(encoding="utf-8")

--- a/tests/test_learn.py
+++ b/tests/test_learn.py
@@ -745,6 +745,22 @@ def test_flash_notices_are_a_fixed_toast(tmp_path):
     assert "click to dismiss" in html
 
 
+def test_learn_page_fits_a_phone_width_exactly(tmp_path):
+    # The page must never scroll sideways on a phone. Two things pushed past the viewport:
+    # a progress row whose title could not shrink beside non-shrinking badges, and the stat
+    # tooltip — a fixed-width absolutely positioned bubble that still contributes scrollable
+    # overflow while invisible, so the rightmost stat's bubble hung off the page edge.
+    repo = _init_repo(tmp_path)
+    html = learn.learn_html(repo.repo)
+    assert ".plist .pl{display:flex;flex-wrap:wrap" in html  # badges drop to their own line
+    assert ".plist .plt{flex:1 1 55%;min-width:0" in html  # the title may shrink
+    # The tooltip anchors to the stats ROW (its positioned ancestor) and is capped at the
+    # row width, so it can never extend past the page no matter which stat is hovered.
+    assert "flex-wrap:wrap;margin-bottom:10px;position:relative}" in html
+    assert ".pstat{cursor:help}" in html
+    assert "width:min(240px,100%)" in html
+
+
 def test_dashboard_serves_learn_routes(tmp_path, monkeypatch, fixed_identity):
     # End-to-end over HTTP: the live dashboard server exposes the page, the state
     # endpoint, and the POST endpoints (here: a progress write for an unknown lesson,

--- a/uv.lock
+++ b/uv.lock
@@ -8,7 +8,7 @@ resolution-markers = [
 
 [[package]]
 name = "agitrack"
-version = "0.5.13"
+version = "0.5.14"
 source = { editable = "." }
 dependencies = [
     { name = "prompt-toolkit" },


### PR DESCRIPTION
The incomplete v0.5.14 release was caused by a transient PyPI timeout after the version bump merged. Both `release-patch.yml` and `release- tag.yml` now retry uploads five times with exponential backoff and pass `--check-url` to skip already-uploaded files, preventing half-releases. The learn page's horizontal scrollbar had two root causes: progress-list
 titles couldn't shrink due to `min-width:auto`, causing long titles to
overflow, and absolutely positioned stat tooltips contributed scrollable
 overflow even when invisible. Titles now shrink and wrap, while
tooltips anchor to the row itself and cap at its width. The "see example
 →" scroll-to-anchor had platform-specific bugs: mobile reserved the
filter bar's height even though it's `position:relative` there, placing the target 336px too low; this now measures from actually-stuck elements
 (banner only on mobile). Desktop had visible overshoot from
`html{scroll-behavior:smooth}` animating every correction; corrections now jump instantly. Removed "brew" from the update message in both the dashboard banner and `update_reminder_line`, ensuring consistent wording
 across all surfaces. All changes include tests and are verified across
320–1200px viewports.

# Interaction Trace

> This commit accounts for 2 commits the agent made itself — their
> hashes are listed under `covered_commits` in the metadata below. Those
> commits keep their own hashes and are never rewritten; the interaction
> trace and the token usage for the work that produced them are recorded
> here, so this commit's token counts span changes already present in
> history.

## User

The last release patch failed. Please check for the reason and see if anything needs to be fixed. In addition, the learn page shows a horizontal scroll bar on a mobile phone; make it fit the width exactly when viewed on mobile. The "see example →" in Turns become commits doesn't scroll to the correct position when viewed on a mobile phone; on
 a laptop browser, the final position is correct but it seems to be
scrolling down and then a bit up which appears unusual, so this needs to
 be fixed too.

## User

The workflow log shows that PyPI upload failed

## User

Remove "brew" from "update via pip/pipx/brew" in the live dashboard, since we currently don't have a brew package available

## Agent

All four items are done. Here's what I found and changed.

**The release failure was a transient PyPI outage, not a code bug.** `uv
 publish` timed out connecting to `upload.pypi.org` after ~48 seconds.
The damage is that it failed *after* the version bump had already merged: v0.5.14 is in main and tagged in `pyproject.toml`, but PyPI still serves 0.5.13, no GitHub release exists, and the extension and Windows MSI never ran. Nothing is corrupted — the release is simply incomplete.

Two changes so this can't half-release again: both `release-patch.yml` and `release-tag.yml` now retry the upload five times with escalating backoff, and pass `--check-url https://pypi.org/simple/agitrack/` so a retry skips a file that actually landed before the client gave up, instead of failing as a duplicate.

**To finish v0.5.14**, push the tag: `git tag v0.5.14 && git push origin
 v0.5.14`. That fires `release-tag.yml`, which checks out main, finds
the version files already in sync (so it opens no PR), then publishes to
 PyPI, creates the GitHub release, publishes the extension, and attaches
 the MSI. I've left this for you since publishing to PyPI is
irreversible — say the word and I'll run it.

**The learn page's horizontal scrollbar** had two causes. Progress-list rows couldn't shrink (the lesson title had the default `min-width:auto` while the badges beside it were `flex:none`), so long titles pushed the row past the viewport; rows now wrap and the title shrinks. The subtler one: the stat tooltip is a 240px absolutely positioned `::after` bubble anchored to each stat — and an absolutely positioned box contributes scrollable overflow *even while invisible*, so the rightmost stat's hidden bubble hung off the page edge. It now anchors to the stats row and is capped at the row's width, so it can never reach past the page. Verified at 320/390/430/768/1200px: zero overflow, tooltip still 240px and working.

**The "see example →" scroll** had one bug per platform. On mobile it reserved the filter bar's height even though the bar is `position:relative` there (it scrolls away), parking the commit 336px down with a screenful of earlier commits above it; the offset is now measured from the elements that are *actually* stuck, so on a phone only
 the banner counts (108px) while desktop is unchanged. The down-then-up
motion came from `html{scroll-behavior:smooth}` — every correction animated, and the next correction measured a mid-animation position and overshot. Corrections now scroll instantly with the page default restored afterward. Measured before/after: desktop went from ~30 animated steps with visible overshoot to 2 steps with zero overshoot; phone from 336px misplacement to a clean single jump.

**"brew" is gone** from the update message. I changed it in two places, not one: the dashboard banner you mentioned, and `update_reminder_line` in `update/marker.py`, whose docstring says it's shared by every surface
 for consistent wording — both now read "update via pip/pipx".

Full check suite passes (2316 tests), both daemons and the preview at http://127.0.0.1:8940/ are running the new code, and I added tests plus FLOW_MATRIX rows for the learn-page fit and the trace-scroll behavior. One note: the em-dash guard in `test_learn_html_contains_the_page` caught my CSS comments — worth remembering that no em-dash may appear anywhere in that page's source, comments included.

# aGiTrack Metadata
commit_type: agent
backend: claude
model: claude-opus-5
reasoning_effort: on
session_name: crab
agitrack_session_id: agitrack-ff15afec-4b0d-4822-a356-1e314c4d674c backend_session_id: 0a14713a-2774-45fe-8904-21d543db8fc4 conversation_anchor: msg_011CdSExJivoyrYvfyYtPbzS
covered_commits: a1a7939 9bb7305
agent_started_at: 2026-07-27T07:58:13Z
agent_ended_at: 2026-07-27T08:24:41Z
context_tokens: 277597
tokens_since_last_commit_input: 257052
tokens_since_last_commit_cache_read: 10898183
tokens_since_last_commit_cache_write: 256967
tokens_since_last_commit_output: 35007
system: macOS 15.7.3
agitrack_version: 0.5.12