### PR TITLE
<aGiTrack> Fixed broken demo deployment by restoring workflow build source

### DIFF
--- a/.github/workflows/pages.yml
+++ b/.github/workflows/pages.yml
@@ -2,8 +2,12 @@
 # a freshly generated static demo dashboard (`agitrack -d export`) under /dashboard/, so the
 # demo is the repository's real, current history on every push to main.
 #
-# Requires the repository's Pages settings to use the "GitHub Actions" source (not the
-# legacy main:/docs branch build); actions/configure-pages switches it on first run.
+# Requires the repository's Pages settings to use the "GitHub Actions" source. If they are
+# ever switched to the legacy main:/docs branch build, THAT builder publishes docs/ alone and
+# silently drops the generated /dashboard/ demo (it has happened) - and because it shares this
+# workflow's "pages" concurrency group it can even deploy last and overwrite this run. The
+# "Enforce the workflow build source" step below therefore re-asserts it on every deploy;
+# actions/configure-pages only enables Pages, it does not flip an existing legacy source.
 name: pages
 
 on:
@@ -45,6 +49,27 @@ jobs:
           agitrack -d export --export-dir "$RUNNER_TEMP/site/dashboard"
       - name: Assemble the site (docs + demo dashboard)
         run: cp -R docs/. "$RUNNER_TEMP/site/"
+      # Fail here rather than deploying a site whose demo silently vanished (a failed or
+      # partial export would otherwise publish the landing pages with dead demo links).
+      - name: Verify the demo is in the site
+        run: |
+          test -f "$RUNNER_TEMP/site/dashboard/index.html"
+          test -f "$RUNNER_TEMP/site/dashboard/learn/index.html"
+          test -f "$RUNNER_TEMP/site/index.html"
+      - name: Enforce the workflow build source
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        run: |
+          current=$(gh api "repos/${{ github.repository }}/pages" --jq .build_type 2>/dev/null || echo "")
+          if [ "$current" = "workflow" ]; then
+            echo "Pages already builds from this workflow."
+          else
+            echo "::warning::Pages build_type is '${current:-unset}' (the legacy branch build \
+          publishes docs/ only and drops /dashboard/); switching it to 'workflow'."
+            gh api -X PUT "repos/${{ github.repository }}/pages" -f build_type=workflow \
+              || echo "::error::could not switch the Pages source to 'workflow' - set it by hand \
+          under Settings > Pages > Build and deployment > Source: GitHub Actions."
+          fi
       - uses: actions/configure-pages@v5
       - uses: actions/upload-pages-artifact@v3
         with:

--- a/tests/FLOW_MATRIX.md
+++ b/tests/FLOW_MATRIX.md
@@ -258,7 +258,10 @@ directory that is not a git repo still gets the full page, with progress sync re
 
 ## 12c. Static demo export (`agitrack -d export`, `tests/test_export.py`)
 A server-free copy of the dashboard + learn page for static hosts (powers the public demo at
-agitrack.core-aix.org/dashboard/, rebuilt by `.github/workflows/pages.yml` on each push to main).
+agitrack.core-aix.org/dashboard/, rebuilt by `.github/workflows/pages.yml` on each push to main). That
+workflow re-asserts the "GitHub Actions" Pages source on every run and refuses to deploy a site without
+`dashboard/index.html`: the legacy `main:/docs` branch build publishes docs/ alone, so if the source drifts
+back to it the public demo 404s.
 | Sequence | Test(s) | Kind |
 |---|---|---|
 | Export is complete: every /data granularity, every /log page for every sort, every in-scope commit's /diff, the whole file browser (filelog + per-change filediff) baked as files | `test_export_writes_a_complete_static_site` | real-git |


### PR DESCRIPTION
The deployed website's demo pages disappeared because GitHub Pages was configured to build from the legacy `main:/docs` source instead of the workflow. This builder only publishes static documentation and has no knowledge of `pages.yml`, which generates the demo site. The legacy builder also shared a concurrency group with the workflow, causing it to
 race and overwrite the full site on every push—leaving landing pages
intact but the demo missing.

The fix involved two parts: immediately switching the Pages source back to `workflow` via the GitHub API and triggering a full redeploy to restore live URLs, then adding permanent safeguards to `pages.yml` to prevent silent recurrence. The workflow now verifies that critical demo files (`dashboard/index.html`, `dashboard/learn/index.html`, `index.html`) exist before deploying, failing the build if they're missing. A second step enforces that the build source is set to `workflow`, either auto-correcting it via API or failing with instructions for manual correction if permissions are insufficient.

The changes maintain the existing deployment architecture while adding explicit verification steps that would have caught this configuration drift immediately. Documentation in `FLOW_MATRIX` now records this as a deployment invariant. A pending PyPI release (v0.5.14) was previously interrupted by upload timeout and awaits approval to complete with `git push origin v0.5.14`.

# Interaction Trace

## User

The deployed webpage doesn't have the static demo pages now. This needs to be fixed immediately.

## Agent

The public demo is live again — https://agitrack.core-aix.org/dashboard/
 and [PATH] both return 200, serving today's fixes.

**What broke.** The repository's Pages source had drifted to the legacy branch build (`main:/docs`). That builder publishes the `docs/` folder verbatim and knows nothing about `pages.yml`, which is what generates the demo into `[PATH]` — so the landing pages deployed fine while the demo simply didn't exist. Worse, the legacy builder shares the `pages` concurrency group with our workflow, so on each push to main it raced and deployed *last*: our full site was built and uploaded, then overwritten by a docs-only deploy. That's why the site looked healthy apart from the missing demo.

`actions/configure-pages` didn't catch it because that action only *enables* Pages when it's off; it doesn't flip an already-configured legacy source back to workflow.

**What I did.** Switched the Pages source back to `workflow` via the API, then triggered a full deploy and verified the live URLs plus a baked demo data file (`[PATH]`, 200). With the source set to `workflow`,
 the legacy builder stops running entirely, so the race is gone too.

**So it can't recur silently**, `pages.yml` now has two new steps before
 deploying:

- **Verify the demo is in the site** — fails the deploy if `dashboard/index.html`, `dashboard/learn/index.html`, or the landing `index.html` is missing, so a broken export can never publish a site with dead demo links.
- **Enforce the workflow build source** — reads `build_type` and, if it isn't `workflow`, logs a warning and switches it back; if the token can't (permissions), it emits a CI error naming the exact setting to change by hand rather than deploying into the same trap.

I validated the YAML parses, the step's shell passes `bash -n`, and its read path returns `workflow` against the real repo. The FLOW_MATRIX note
 for the demo section now records this deployment invariant, and the
full check suite passes.

One connected loose end from earlier: v0.5.14 is still unpublished on PyPI (the release stopped at the upload timeout). Pushing `git tag v0.5.14 && git push origin v0.5.14` completes it — I'm holding on that until you say go, since publishing is irreversible.

# aGiTrack Metadata
commit_type: agent
backend: claude
model: claude-opus-5
reasoning_effort: on
session_name: crab
agitrack_session_id: agitrack-ff15afec-4b0d-4822-a356-1e314c4d674c backend_session_id: 0a14713a-2774-45fe-8904-21d543db8fc4 conversation_anchor: msg_011CdSKwdHSYXY3KjXQKwKrE
agent_started_at: 2026-07-27T09:20:28Z
agent_ended_at: 2026-07-27T09:29:56Z
context_tokens: 289610
tokens_since_last_commit_input: 12037
tokens_since_last_commit_cache_read: 3696686
tokens_since_last_commit_cache_write: 12013
tokens_since_last_commit_output: 9051
system: macOS 15.7.3
agitrack_version: 0.5.12