### PR TITLE
Back off before relaunching a repeatedly-exiting backend

### DIFF
--- a/agitrack/proxy/runner.py
+++ b/agitrack/proxy/runner.py
@@ -6235,9 +6235,7 @@ class ProxyRunner(BranchWatchMixin, ManualCommitsMixin, SessionSharingMixin, Upd
         now = time.monotonic()
         recent = [t for t in self._relaunch_times if now - t < _RELAUNCH_WINDOW_SECONDS]
         if len(recent) >= 3:
-            self._debug(
-                f"backend exited 3x within {_RELAUNCH_WINDOW_SECONDS:.0f}s; quitting instead of relaunching"
-            )
+            self._debug(f"backend exited 3x within {_RELAUNCH_WINDOW_SECONDS:.0f}s; quitting instead of relaunching")
             self._backend_exit_notice = self._format_backend_exit_notice()
             self._finalize_on_backend_exit()
             return False

--- a/agitrack/proxy/runner.py
+++ b/agitrack/proxy/runner.py
@@ -275,6 +275,16 @@ _MAX_HELD_REPLY_BYTES = 256
 # automatically rather than crash-looping and exiting (#114).
 _FORK_HINT_RE = re.compile(r"running as a background agent|--fork-session", re.IGNORECASE)
 
+# Crash-loop guard for a repeatedly-exiting backend (_relaunch_backend_or_exit). The window
+# must comfortably exceed the total backoff below plus spawn overhead, or the guard's own
+# bookkeeping trips before the backoff it is meant to accommodate finishes playing out.
+_RELAUNCH_WINDOW_SECONDS = 20.0
+# Delay before the 1st/2nd/3rd relaunch attempt. No delay on the first retry (most exits are
+# not auth-related — Esc from the session picker, a clean `/exit` — and should resume
+# instantly); increasing delay after, so a backend whose apiKeyHelper is momentarily slow
+# (1Password/biometric unlock) gets real wall-clock time to succeed before the guard gives up.
+_RELAUNCH_BACKOFF_SECONDS: tuple[float, ...] = (0.0, 1.5, 4.0)
+
 
 # Sentinel: the summarizer-model picker was dismissed (Esc), distinct from a real None choice
 # ("same as the session model"). Lets _choose_summarizer_model report "no change" unambiguously.
@@ -6223,15 +6233,27 @@ class ProxyRunner(BranchWatchMixin, ManualCommitsMixin, SessionSharingMixin, Upd
                 return False
             return True
         now = time.monotonic()
-        recent = [t for t in self._relaunch_times if now - t < 12.0]
+        recent = [t for t in self._relaunch_times if now - t < _RELAUNCH_WINDOW_SECONDS]
         if len(recent) >= 3:
-            self._debug("backend exited 3x within 12s; quitting instead of relaunching")
+            self._debug(
+                f"backend exited 3x within {_RELAUNCH_WINDOW_SECONDS:.0f}s; quitting instead of relaunching"
+            )
             self._backend_exit_notice = self._format_backend_exit_notice()
             self._finalize_on_backend_exit()
             return False
         recent.append(now)
         self._relaunch_times = recent
         self.child_pid = None  # already gone
+        # A backend that exits INSTANTLY (bad key, no network, apiKeyHelper still warming up
+        # 1Password/biometric auth) can burn all 3 attempts in a fraction of a second, giving a
+        # transient — but slightly slow — credential fetch no real chance to succeed on retry.
+        # Backing off before each relaunch trades a bit of latency in the genuine crash-loop
+        # case (which was going to fail anyway) for a real second and third chance here. Skip
+        # the wait on the very first retry: most exits (Esc from the session picker, a clean
+        # `/exit`) are not auth-related and should resume instantly.
+        delay = _RELAUNCH_BACKOFF_SECONDS[min(len(recent) - 1, len(_RELAUNCH_BACKOFF_SECONDS) - 1)]
+        if delay:
+            time.sleep(delay)
         try:
             # _restart_agent tears down the dead PTY, re-baselines (so existing
             # history is not re-committed) and respawns; _spawn resumes the same

--- a/tests/test_proxy.py
+++ b/tests/test_proxy.py
@@ -8050,6 +8050,7 @@ def test_relaunch_backend_resumes_then_gives_up_on_crash_loop(monkeypatch):
 
     t = [1000.0]
     monkeypatch.setattr("agitrack.proxy.runner.time.monotonic", lambda: t[0])
+    monkeypatch.setattr("agitrack.proxy.runner.time.sleep", lambda _seconds: None)
 
     # Backend keeps dying quickly: first 3 relaunch, the 4th gives up and exits.
     assert runner._relaunch_backend_or_exit() is True
@@ -8074,6 +8075,7 @@ def test_crash_loop_capture_surfaces_backend_output(monkeypatch):
 
     t = [1000.0]
     monkeypatch.setattr("agitrack.proxy.runner.time.monotonic", lambda: t[0])
+    monkeypatch.setattr("agitrack.proxy.runner.time.sleep", lambda _seconds: None)
     for _ in range(3):
         assert runner._relaunch_backend_or_exit() is True
     assert runner._relaunch_backend_or_exit() is False
@@ -8098,6 +8100,7 @@ def test_backend_exit_notice_shows_the_launched_command(monkeypatch):
 
     t = [1000.0]
     monkeypatch.setattr("agitrack.proxy.runner.time.monotonic", lambda: t[0])
+    monkeypatch.setattr("agitrack.proxy.runner.time.sleep", lambda _seconds: None)
     for _ in range(3):
         runner._relaunch_backend_or_exit()
     runner._relaunch_backend_or_exit()
@@ -8108,7 +8111,7 @@ def test_backend_exit_notice_shows_the_launched_command(monkeypatch):
     assert "no output before exiting" in notice  # explicit, not an empty section
 
 
-def test_busy_session_forks_instead_of_crash_looping():
+def test_busy_session_forks_instead_of_crash_looping(monkeypatch):
     # The claude session is held by a running background agent. aGiTrack should fork a
     # copy on the next spawn rather than relaunch into the same refusal (#114).
     import types
@@ -8123,6 +8126,7 @@ def test_busy_session_forks_instead_of_crash_looping():
     runner._debug = lambda *a, **k: None
     messages = []
     runner._restart_agent = lambda msg: messages.append(msg)
+    monkeypatch.setattr("agitrack.proxy.runner.time.sleep", lambda _seconds: None)
 
     # First death: fork once.
     assert runner._relaunch_backend_or_exit() is True
@@ -8150,6 +8154,28 @@ def test_claude_spawn_command_fork_appends_flag():
     assert "--fork-session" not in cmd_plain
 
 
+def test_relaunch_backend_backs_off_before_retrying(monkeypatch):
+    # A backend that exits instantly (e.g. a slow apiKeyHelper still fetching credentials)
+    # must not burn all 3 relaunch attempts before the credential fetch had a real chance to
+    # finish. No delay on the first retry (most exits are unrelated to auth and should
+    # resume immediately); increasing delay on the 2nd/3rd give a slow helper time to
+    # succeed instead of racing straight into the crash-loop guard.
+    runner = make_runner()
+    runner._debug = lambda *a, **k: None
+    runner._restart_agent = lambda msg: None
+    runner._finalize_on_backend_exit = lambda: None
+
+    t = [1000.0]
+    sleeps = []
+    monkeypatch.setattr("agitrack.proxy.runner.time.monotonic", lambda: t[0])
+    monkeypatch.setattr("agitrack.proxy.runner.time.sleep", lambda seconds: sleeps.append(seconds))
+
+    for _ in range(3):
+        runner._relaunch_backend_or_exit()
+
+    assert sleeps == [1.5, 4.0]
+
+
 def test_relaunch_backend_resets_loop_guard_after_quiet_period(monkeypatch):
     runner = make_runner()
     runner._debug = lambda *a, **k: None
@@ -8159,6 +8185,7 @@ def test_relaunch_backend_resets_loop_guard_after_quiet_period(monkeypatch):
 
     t = [1000.0]
     monkeypatch.setattr("agitrack.proxy.runner.time.monotonic", lambda: t[0])
+    monkeypatch.setattr("agitrack.proxy.runner.time.sleep", lambda _seconds: None)
     for _ in range(3):
         runner._relaunch_backend_or_exit()
     t[0] += 60.0  # a minute later the old exits no longer count

--- a/uv.lock
+++ b/uv.lock
@@ -8,7 +8,7 @@ resolution-markers = [
 
 [[package]]
 name = "agitrack"
-version = "0.6.19"
+version = "0.6.20"
 source = { editable = "." }
 dependencies = [
     { name = "prompt-toolkit" },


### PR DESCRIPTION
## What happened

Launching aGiTrack with an `ANTHROPIC_API_KEY` supplied via Claude Code's
`apiKeyHelper` (a script that reads the key from a password manager, e.g.
1Password) could make aGiTrack appear to stall and then quit with no
error message at all.

Root cause: `claude` sometimes exited immediately instead of
starting. aGiTrack's crash-loop guard relaunches a repeatedly-exiting
backend up to 3 times within a fixed window before giving up — but with
**no delay between attempts**, a backend that exits instantly could burn
all 3 attempts immediately, well before a slow
credential fetch (triggered by the user's authorization) had any real chance to succeed on a retry.

## What changed

- `_relaunch_backend_or_exit` now backs off before each relaunch attempt:
  0s before the 1st retry (most exits are unrelated to auth — Esc from
  the session picker, a clean `/exit` — and should resume instantly),
  1.5s before the 2nd, 4s before the 3rd.
- Widened the crash-loop window from 12s to 20s so it comfortably covers
  the new backoff plus spawn overhead, without changing the "3 strikes"
  threshold itself — a genuinely broken backend still gives up and
  surfaces the existing exit notice.

## Test plan

- [x] `uv run pytest tests/test_proxy.py -q` — 644 passed
- [x] Added `test_relaunch_backend_backs_off_before_retrying` asserting
      the exact backoff schedule
- [x] Updated existing crash-loop tests to stub `time.sleep`
- [x] `uv run ruff check` / `uv run mypy` clean on the touched module